### PR TITLE
Closes #27 by correctly reporting time unit

### DIFF
--- a/h5bench_patterns/h5bench_write.c
+++ b/h5bench_patterns/h5bench_write.c
@@ -1081,13 +1081,13 @@ main(int argc, char *argv[])
         float meta_time_s = (float)inner_metadata_time / (1000 * 1000);
         printf("Metadata time = %.3f sec\n", meta_time_s);
 
-        float fcreate_time_s = (float)(tfopen_end - tfopen_start);
+        float fcreate_time_s = (float)(tfopen_end - tfopen_start) / (1000 * 1000);
         printf("H5Fcreate() takes %.3f sec\n", fcreate_time_s);
 
-        float flush_time_s = (float)(tflush_end - tflush_start);
+        float flush_time_s = (float)(tflush_end - tflush_start) / (1000 * 1000);
         printf("H5Fflush() takes %.3f sec\n", flush_time_s);
 
-        float fclose_time_s = (float)(tfclose_end - tfclose_start);
+        float fclose_time_s = (float)(tfclose_end - tfclose_start) / (1000 * 1000);
         printf("H5Fclose() takes %.3f sec\n", fclose_time_s);
 
         float oct_s = (float)(t4 - t1) / (1000 * 1000);


### PR DESCRIPTION
Closes #27 by correctly reporting time unit for  `H5Fcreate()`, `H5Fflush()`, and `H5Fclose()`, all in seconds with 3 digits after the decimal point.