### PR TITLE
Include options to enable additional benchmarks

### DIFF
--- a/CMake/FindHDF5_VOL_ASYNC.cmake
+++ b/CMake/FindHDF5_VOL_ASYNC.cmake
@@ -1,0 +1,31 @@
+set(ASYNC_HOME $ENV{ASYNC_HOME})
+
+find_path(HDF5_VOL_ASYNC_INCLUDE_DIR
+    NAMES h5_async_lib.h h5_async_vol.h
+    PATHS "$ASYNC_HOME"
+)
+
+find_library(HDF5_VOL_ASYNC_LIBRARY
+    NAMES asynchdf5 h5async
+    PATHS "$ASYNC_HOME"
+)
+
+message(STATUS ${HDF5_VOL_ASYNC_INCLUDE_DIR})
+message(STATUS ${HDF5_VOL_ASYNC_LIBRARY})
+
+set(HDF5_VOL_ASYNC_INCLUDE_DIRS ${HDF5_VOL_ASYNC_INCLUDE_DIR})
+set(HDF5_VOL_ASYNC_LIBRARIES ${HDF5_VOL_ASYNC_LIBRARY})
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(
+    HDF5_VOL_ASYNC
+    DEFAULT_MSG
+    HDF5_VOL_ASYNC_LIBRARIES
+    HDF5_VOL_ASYNC_INCLUDE_DIRS
+)
+
+mark_as_advanced(
+    HDF5_VOL_ASYNC_LIBRARY
+    HDF5_VOL_ASYNC_INCLUDE_DIR
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,12 +15,34 @@ include_directories(SYSTEM ${MPI_INCLUDE_PATH})
 # Options and Variants ########################################################
 #
 
-option(H5BENCH_ALL                "Enable all benchmarks"             OFF)
-option(H5BENCH_E3SM               "Enable E3SM benchmark"             OFF)
+set(CMAKE_BUILD_TYPE Debug)
 
+option(H5BENCH_ALL              "Enable all benchmarks"             OFF)
+option(H5BENCH_METADATA 		"Enable Metadata benchmark"			OFF)
+option(H5BENCH_EXERCISER	 	"Enable Exerciser benchmark"		OFF)
+option(H5BENCH_AMREX 			"Enable AMReX benchmark"			OFF)
+option(H5BENCH_OPENPMD        	"Enable OpenPMD benchmark"          OFF)
+option(H5BENCH_E3SM           	"Enable E3SM benchmark"             OFF)
+
+message(STATUS "h5bench baseline: ON")
+
+if(H5BENCH_ALL)
+	message(STATUS "h5bench ENABLE ALL benchmarks")
+
+	set(H5BENCH_METADATA ON)
+	set(H5BENCH_EXERCISER ON)
+	set(H5BENCH_AMREX ON)
+	set(H5BENCH_OPENPMD ON)
+	set(H5BENCH_E3SM ON)
+endif()
+
+message(STATUS "h5bench METADATA: ${H5BENCH_METADATA}")
+message(STATUS "h5bench EXERCISER: ${H5BENCH_EXERCISER}")
+message(STATUS "h5bench AMREX: ${H5BENCH_AMREX}")
+message(STATUS "h5bench OPENPMD: ${H5BENCH_OPENPMD}")
 message(STATUS "h5bench E3SM: ${H5BENCH_E3SM}")
 
-if(H5BENCH_E3SM OR H5BENCH_ALL)
+if(H5BENCH_E3SM)
 	set(PNETCDF_HOME $ENV{PNETCDF_HOME})
 	set(CMAKE_PREFIX_PATH ${PNETCDF_HOME})
 
@@ -42,6 +64,7 @@ include_directories(${HDF5_HOME}/include)
 link_directories(${HDF5_HOME}/lib)
 
 # VOL ASYNC Dependency ########################################################
+#
 
 set(ASYNC_HOME $ENV{ASYNC_HOME})
 option(WITH_ASYNC_VOL "Enable HDF5 VOL ASYNC connector" OFF)
@@ -58,18 +81,19 @@ endif()
 
 message(STATUS "HDF5 VOL ASYNC: ${WITH_ASYNC_VOL}")
 
-# =========== Utilility libs ==============
+# h5bench Utility #############################################################
+#
+
 set(h5bench_util_src
     commons/h5bench_util.c
     commons/h5bench_util.h
 )
+
 add_library(h5bench_util ${h5bench_util_src})
+
 if(WITH_ASYNC_VOL)
 	target_link_libraries(h5bench_util asynchdf5 h5async)
 endif()
-# =================================================================
-
-set(CMAKE_BUILD_TYPE Debug)
 
 # h5bench WRITE ###############################################################
 #
@@ -116,56 +140,64 @@ target_link_libraries(h5bench_read h5bench_util hdf5 z MPI::MPI_C)
 # Exerciser ###################################################################
 #
 
-set(exerciser_src exerciser/h5bench_exerciser.c)
+if(H5BENCH_EXERCISER)
+	set(exerciser_src exerciser/h5bench_exerciser.c)
 
-add_executable(h5bench_exerciser ${exerciser_src})
+	add_executable(h5bench_exerciser ${exerciser_src})
 
-target_link_libraries(h5bench_exerciser hdf5 z m MPI::MPI_C)
+	target_link_libraries(h5bench_exerciser hdf5 z m MPI::MPI_C)
+endif()
 
 # IOTEST ######################################################################
 #
 
-set(meta_stress_src
-	metadata_stress/hdf5_iotest.c
-	metadata_stress/configuration.c
-	metadata_stress/configuration.h
-	metadata_stress/dataset.c
-	metadata_stress/dataset.h
-	metadata_stress/ini.c
-	metadata_stress/ini.h
-)
-add_executable(h5bench_hdf5_iotest ${meta_stress_src})
-target_link_libraries(h5bench_hdf5_iotest h5bench_util hdf5 z m MPI::MPI_C)
+if(H5BENCH_EXERCISER)
+	set(meta_stress_src
+		metadata_stress/hdf5_iotest.c
+		metadata_stress/configuration.c
+		metadata_stress/configuration.h
+		metadata_stress/dataset.c
+		metadata_stress/dataset.h
+		metadata_stress/ini.c
+		metadata_stress/ini.h
+	)
+
+	add_executable(h5bench_hdf5_iotest ${meta_stress_src})
+
+	target_link_libraries(h5bench_hdf5_iotest h5bench_util hdf5 z m MPI::MPI_C)
+endif()
 
 # AMReX #######################################################################
 #
 # https://github.com/AMReX-Codes/amrex/tree/development/Tests/HDF5Benchmark
 
-set(AMReX_HDF5 YES)
-set(AMReX_PARTICLES YES)
-set(AMReX_MPI_THREAD_MULTIPLE YES)
+if(H5BENCH_AMREX)
+	set(AMReX_HDF5 YES)
+	set(AMReX_PARTICLES YES)
+	set(AMReX_MPI_THREAD_MULTIPLE YES)
 
-add_subdirectory(amrex)
+	add_subdirectory(amrex)
 
-set(amrex_src amrex/Tests/HDF5Benchmark/main.cpp)
+	set(amrex_src amrex/Tests/HDF5Benchmark/main.cpp)
 
-add_executable(h5bench_amrex_sync ${amrex_src})
-target_link_libraries(h5bench_amrex_sync hdf5 z m amrex pthread MPI::MPI_C)
+	add_executable(h5bench_amrex_sync ${amrex_src})
+	target_link_libraries(h5bench_amrex_sync hdf5 z m amrex pthread MPI::MPI_C)
 
-if(WITH_ASYNC_VOL)
-	set(AMReX_HDF5_ASYNC YES)
-	
-	add_executable(h5bench_amrex_async ${amrex_src})
-	target_link_libraries(h5bench_amrex_async hdf5 z m amrex pthread asynchdf5 h5async MPI::MPI_C)
+	if(WITH_ASYNC_VOL)
+		set(AMReX_HDF5_ASYNC YES)
+		
+		add_executable(h5bench_amrex_async ${amrex_src})
+		target_link_libraries(h5bench_amrex_async hdf5 z m amrex pthread asynchdf5 h5async MPI::MPI_C)
+	endif()
+		
+	configure_file(${CMAKE_SOURCE_DIR}/h5bench ${CMAKE_BINARY_DIR}/h5bench COPYONLY)
 endif()
-	
-configure_file(${CMAKE_SOURCE_DIR}/h5bench ${CMAKE_BINARY_DIR}/h5bench COPYONLY)
 
 # E3SM ########################################################################
 #
 # https://github.com/Parallel-NetCDF/E3SM-IO
 
-if(H5BENCH_E3SM OR H5BENCH_ALL)
+if(H5BENCH_E3SM)
 	ExternalProject_Add(h5bench_e3sm
 	    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/e3sm
 	    CONFIGURE_COMMAND autoreconf -i COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/e3sm/configure --prefix=${CMAKE_BINARY_DIR} --with-pnetcdf=${PNETCDF_HOME} --with-hdf5=${HDF5_HOME} CFLAGS=-fno-var-tracking-assignments CXXFLAGS=-fno-var-tracking-assignments
@@ -181,36 +213,38 @@ endif()
 #
 # https://github.com/openPMD/openPMD-api
 
-set(openPMD_USE_MPI ON)
-set(openPMD_USE_HDF5 ON)
-set(openPMD_USE_ADIOS1 OFF)
-set(openPMD_USE_ADIOS2 OFF)
-set(openPMD_USE_JSON OFF)
-set(openPMD_USE_PYTHON OFF)
-set(openPMD_INSTALL OFF)
-set(openPMD_BUILD_TESTING OFF)
-set(openPMD_BUILD_EXAMPLES OFF)
-set(openPMD_BUILD_CLI_TOOLS OFF)
+if(H5BENCH_OPENPMD)
+	set(openPMD_USE_MPI ON)
+	set(openPMD_USE_HDF5 ON)
+	set(openPMD_USE_ADIOS1 OFF)
+	set(openPMD_USE_ADIOS2 OFF)
+	set(openPMD_USE_JSON OFF)
+	set(openPMD_USE_PYTHON OFF)
+	set(openPMD_INSTALL OFF)
+	set(openPMD_BUILD_TESTING OFF)
+	set(openPMD_BUILD_EXAMPLES OFF)
+	set(openPMD_BUILD_CLI_TOOLS OFF)
 
-add_subdirectory(openpmd)
+	add_subdirectory(openpmd)
 
-add_executable(h5bench_openpmd_write openpmd/examples/8a_benchmark_write_parallel.cpp)
-target_link_libraries(h5bench_openpmd_write openPMD hdf5 MPI::MPI_C)
+	add_executable(h5bench_openpmd_write openpmd/examples/8a_benchmark_write_parallel.cpp)
+	target_link_libraries(h5bench_openpmd_write openPMD hdf5 MPI::MPI_C)
 
-set_target_properties(h5bench_openpmd_write PROPERTIES
-    CXX_EXTENSIONS OFF
-    CXX_STANDARD_REQUIRED ON
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-)
+	set_target_properties(h5bench_openpmd_write PROPERTIES
+	    CXX_EXTENSIONS OFF
+	    CXX_STANDARD_REQUIRED ON
+	    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+	)
 
-add_executable(h5bench_openpmd_read openpmd/examples/8b_benchmark_read_parallel.cpp)
-target_link_libraries(h5bench_openpmd_read openPMD hdf5 MPI::MPI_C)
+	add_executable(h5bench_openpmd_read openpmd/examples/8b_benchmark_read_parallel.cpp)
+	target_link_libraries(h5bench_openpmd_read openPMD hdf5 MPI::MPI_C)
 
-set_target_properties(h5bench_openpmd_read PROPERTIES
-    CXX_EXTENSIONS OFF
-    CXX_STANDARD_REQUIRED ON
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-)
+	set_target_properties(h5bench_openpmd_read PROPERTIES
+	    CXX_EXTENSIONS OFF
+	    CXX_STANDARD_REQUIRED ON
+	    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+	)
+endif()
 
 configure_file(${CMAKE_SOURCE_DIR}/h5bench ${CMAKE_BINARY_DIR}/h5bench COPYONLY)
 
@@ -223,25 +257,43 @@ install(
 	DESTINATION bin
 )
 
-install(
-	TARGETS 
-	h5bench_write 
-	h5bench_write_unlimited
-	h5bench_read 
-	h5bench_overwrite
-	h5bench_append
-	h5bench_exerciser 
-	h5bench_hdf5_iotest 
-	h5bench_openpmd_write
-	h5bench_openpmd_read
-	h5bench_amrex_sync
-	#h5bench_vl_stream_hl
-	DESTINATION bin
-)
-
-if(WITH_ASYNC_VOL)
-	install(TARGETS 
-		h5bench_amrex_async 
+if(H5BENCH_EXERCISER)
+	install(
+		TARGETS
+		h5bench_exerciser 
 		DESTINATION bin
 	)
+endif()
+
+if(H5BENCH_METADATA)
+	install(
+		TARGETS
+		h5bench_hdf5_iotest
+		DESTINATION bin
+	)
+endif()
+
+if(H5BENCH_OPENPMD)
+	install(
+		TARGETS
+		h5bench_openpmd_write
+		h5bench_openpmd_read
+		DESTINATION bin
+	)
+endif()
+
+if(H5BENCH_AMREX)
+	install(
+		TARGETS
+		h5bench_amrex_sync
+		DESTINATION bin
+	)
+
+	if(WITH_ASYNC_VOL)
+		install( 
+			TARGETS
+			h5bench_amrex_async 
+			DESTINATION bin
+		)
+	endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 project(
-	h5bench
+    h5bench
     VERSION 1.3.0
 )
 
@@ -18,22 +18,22 @@ include_directories(SYSTEM ${MPI_INCLUDE_PATH})
 set(CMAKE_BUILD_TYPE Debug)
 
 option(H5BENCH_ALL              "Enable all benchmarks"             OFF)
-option(H5BENCH_METADATA 		"Enable Metadata benchmark"			OFF)
-option(H5BENCH_EXERCISER	 	"Enable Exerciser benchmark"		OFF)
-option(H5BENCH_AMREX 			"Enable AMReX benchmark"			OFF)
-option(H5BENCH_OPENPMD        	"Enable OpenPMD benchmark"          OFF)
-option(H5BENCH_E3SM           	"Enable E3SM benchmark"             OFF)
+option(H5BENCH_METADATA         "Enable Metadata benchmark"         OFF)
+option(H5BENCH_EXERCISER        "Enable Exerciser benchmark"        OFF)
+option(H5BENCH_AMREX            "Enable AMReX benchmark"            OFF)
+option(H5BENCH_OPENPMD          "Enable OpenPMD benchmark"          OFF)
+option(H5BENCH_E3SM             "Enable E3SM benchmark"             OFF)
 
 message(STATUS "h5bench baseline: ON")
 
 if(H5BENCH_ALL)
-	message(STATUS "h5bench ENABLE ALL benchmarks")
+    message(STATUS "h5bench ENABLE ALL benchmarks")
 
-	set(H5BENCH_METADATA ON)
-	set(H5BENCH_EXERCISER ON)
-	set(H5BENCH_AMREX ON)
-	set(H5BENCH_OPENPMD ON)
-	set(H5BENCH_E3SM ON)
+    set(H5BENCH_METADATA ON)
+    set(H5BENCH_EXERCISER ON)
+    set(H5BENCH_AMREX ON)
+    set(H5BENCH_OPENPMD ON)
+    set(H5BENCH_E3SM ON)
 endif()
 
 message(STATUS "h5bench METADATA: ${H5BENCH_METADATA}")
@@ -43,11 +43,11 @@ message(STATUS "h5bench OPENPMD: ${H5BENCH_OPENPMD}")
 message(STATUS "h5bench E3SM: ${H5BENCH_E3SM}")
 
 if(H5BENCH_E3SM)
-	set(PNETCDF_HOME $ENV{PNETCDF_HOME})
-	set(CMAKE_PREFIX_PATH ${PNETCDF_HOME})
+    set(PNETCDF_HOME $ENV{PNETCDF_HOME})
+    set(CMAKE_PREFIX_PATH ${PNETCDF_HOME})
 
-	find_package(PNetCDF REQUIRED)
-	include_directories(${PNETCDF_INCLUDES})
+    find_package(PNetCDF REQUIRED)
+    include_directories(${PNETCDF_INCLUDES})
 endif()
 
 # HDF5 Dependency #############################################################
@@ -70,13 +70,13 @@ set(ASYNC_HOME $ENV{ASYNC_HOME})
 option(WITH_ASYNC_VOL "Enable HDF5 VOL ASYNC connector" OFF)
 
 if(WITH_ASYNC_VOL)
-	if(${HDF5_VERSION} VERSION_GREATER_EQUAL "1.13.0")
-		add_definitions(-DUSE_ASYNC_VOL)
-		include_directories(${ASYNC_HOME})
-		link_directories(${ASYNC_HOME})
-	else()
-		message(SEND_ERROR "VOL ASYNC requires HDF5 1.13.0 or newer.")
-	endif()
+    if(${HDF5_VERSION} VERSION_GREATER_EQUAL "1.13.0")
+        add_definitions(-DUSE_ASYNC_VOL)
+        include_directories(${ASYNC_HOME})
+        link_directories(${ASYNC_HOME})
+    else()
+        message(SEND_ERROR "VOL ASYNC requires HDF5 1.13.0 or newer.")
+    endif()
 endif()
 
 message(STATUS "HDF5 VOL ASYNC: ${WITH_ASYNC_VOL}")
@@ -92,7 +92,7 @@ set(h5bench_util_src
 add_library(h5bench_util ${h5bench_util_src})
 
 if(WITH_ASYNC_VOL)
-	target_link_libraries(h5bench_util asynchdf5 h5async)
+    target_link_libraries(h5bench_util asynchdf5 h5async)
 endif()
 
 # h5bench WRITE ###############################################################
@@ -140,30 +140,30 @@ target_link_libraries(h5bench_read h5bench_util hdf5 z ${CMAKE_DL_LIBS} MPI::MPI
 #
 
 if(H5BENCH_EXERCISER)
-	set(exerciser_src exerciser/h5bench_exerciser.c)
+    set(exerciser_src exerciser/h5bench_exerciser.c)
 
-	add_executable(h5bench_exerciser ${exerciser_src})
+    add_executable(h5bench_exerciser ${exerciser_src})
 
-	target_link_libraries(h5bench_exerciser hdf5 z m ${CMAKE_DL_LIBS} MPI::MPI_C)
+    target_link_libraries(h5bench_exerciser hdf5 z m ${CMAKE_DL_LIBS} MPI::MPI_C)
 endif()
 
 # IOTEST ######################################################################
 #
 
 if(H5BENCH_EXERCISER)
-	set(meta_stress_src
-		metadata_stress/hdf5_iotest.c
-		metadata_stress/configuration.c
-		metadata_stress/configuration.h
-		metadata_stress/dataset.c
-		metadata_stress/dataset.h
-		metadata_stress/ini.c
-		metadata_stress/ini.h
-	)
+    set(meta_stress_src
+        metadata_stress/hdf5_iotest.c
+        metadata_stress/configuration.c
+        metadata_stress/configuration.h
+        metadata_stress/dataset.c
+        metadata_stress/dataset.h
+        metadata_stress/ini.c
+        metadata_stress/ini.h
+    )
 
-	add_executable(h5bench_hdf5_iotest ${meta_stress_src})
+    add_executable(h5bench_hdf5_iotest ${meta_stress_src})
 
-	target_link_libraries(h5bench_hdf5_iotest h5bench_util hdf5 z m ${CMAKE_DL_LIBS} MPI::MPI_C)
+    target_link_libraries(h5bench_hdf5_iotest h5bench_util hdf5 z m ${CMAKE_DL_LIBS} MPI::MPI_C)
 endif()
 
 # AMReX #######################################################################
@@ -171,25 +171,25 @@ endif()
 # https://github.com/AMReX-Codes/amrex/tree/development/Tests/HDF5Benchmark
 
 if(H5BENCH_AMREX)
-	set(AMReX_HDF5 YES)
-	set(AMReX_PARTICLES YES)
-	set(AMReX_MPI_THREAD_MULTIPLE YES)
+    set(AMReX_HDF5 YES)
+    set(AMReX_PARTICLES YES)
+    set(AMReX_MPI_THREAD_MULTIPLE YES)
 
-	add_subdirectory(amrex)
+    add_subdirectory(amrex)
 
-	set(amrex_src amrex/Tests/HDF5Benchmark/main.cpp)
+    set(amrex_src amrex/Tests/HDF5Benchmark/main.cpp)
 
-	add_executable(h5bench_amrex_sync ${amrex_src})
-	target_link_libraries(h5bench_amrex_sync hdf5 z m amrex pthread ${CMAKE_DL_LIBS} MPI::MPI_C)
+    add_executable(h5bench_amrex_sync ${amrex_src})
+    target_link_libraries(h5bench_amrex_sync hdf5 z m amrex pthread ${CMAKE_DL_LIBS} MPI::MPI_C)
 
-	if(WITH_ASYNC_VOL)
-		set(AMReX_HDF5_ASYNC YES)
-		
-		add_executable(h5bench_amrex_async ${amrex_src})
-		target_link_libraries(h5bench_amrex_async hdf5 z m amrex pthread asynchdf5 h5async ${CMAKE_DL_LIBS} MPI::MPI_C)
-	endif()
-		
-	configure_file(${CMAKE_SOURCE_DIR}/h5bench ${CMAKE_BINARY_DIR}/h5bench COPYONLY)
+    if(WITH_ASYNC_VOL)
+        set(AMReX_HDF5_ASYNC YES)
+        
+        add_executable(h5bench_amrex_async ${amrex_src})
+        target_link_libraries(h5bench_amrex_async hdf5 z m amrex pthread asynchdf5 h5async ${CMAKE_DL_LIBS} MPI::MPI_C)
+    endif()
+        
+    configure_file(${CMAKE_SOURCE_DIR}/h5bench ${CMAKE_BINARY_DIR}/h5bench COPYONLY)
 endif()
 
 # E3SM ########################################################################
@@ -197,15 +197,15 @@ endif()
 # https://github.com/Parallel-NetCDF/E3SM-IO
 
 if(H5BENCH_E3SM)
-	ExternalProject_Add(h5bench_e3sm
-	    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/e3sm
-	    CONFIGURE_COMMAND autoreconf -i COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/e3sm/configure --prefix=${CMAKE_BINARY_DIR} --with-pnetcdf=${PNETCDF_HOME} --with-hdf5=${HDF5_HOME} CFLAGS=-fno-var-tracking-assignments CXXFLAGS=-fno-var-tracking-assignments
-	    BUILD_COMMAND make
-	    INSTALL_COMMAND ${CMAKE_COMMAND} -E copy src/e3sm_io ${CMAKE_BINARY_DIR}/h5bench_e3sm 
-	    BUILD_IN_SOURCE 1
-	    LOG_CONFIGURE 1
-	    LOG_BUILD 1
-	)
+    ExternalProject_Add(h5bench_e3sm
+        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/e3sm
+        CONFIGURE_COMMAND autoreconf -i COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/e3sm/configure --prefix=${CMAKE_BINARY_DIR} --with-pnetcdf=${PNETCDF_HOME} --with-hdf5=${HDF5_HOME} CFLAGS=-fno-var-tracking-assignments CXXFLAGS=-fno-var-tracking-assignments
+        BUILD_COMMAND make
+        INSTALL_COMMAND ${CMAKE_COMMAND} -E copy src/e3sm_io ${CMAKE_BINARY_DIR}/h5bench_e3sm 
+        BUILD_IN_SOURCE 1
+        LOG_CONFIGURE 1
+        LOG_BUILD 1
+    )
 endif()
 
 # OpenPMD #####################################################################
@@ -213,36 +213,36 @@ endif()
 # https://github.com/openPMD/openPMD-api
 
 if(H5BENCH_OPENPMD)
-	set(openPMD_USE_MPI ON)
-	set(openPMD_USE_HDF5 ON)
-	set(openPMD_USE_ADIOS1 OFF)
-	set(openPMD_USE_ADIOS2 OFF)
-	set(openPMD_USE_JSON OFF)
-	set(openPMD_USE_PYTHON OFF)
-	set(openPMD_INSTALL OFF)
-	set(openPMD_BUILD_TESTING OFF)
-	set(openPMD_BUILD_EXAMPLES OFF)
-	set(openPMD_BUILD_CLI_TOOLS OFF)
+    set(openPMD_USE_MPI ON)
+    set(openPMD_USE_HDF5 ON)
+    set(openPMD_USE_ADIOS1 OFF)
+    set(openPMD_USE_ADIOS2 OFF)
+    set(openPMD_USE_JSON OFF)
+    set(openPMD_USE_PYTHON OFF)
+    set(openPMD_INSTALL OFF)
+    set(openPMD_BUILD_TESTING OFF)
+    set(openPMD_BUILD_EXAMPLES OFF)
+    set(openPMD_BUILD_CLI_TOOLS OFF)
 
-	add_subdirectory(openpmd)
+    add_subdirectory(openpmd)
 
-	add_executable(h5bench_openpmd_write openpmd/examples/8a_benchmark_write_parallel.cpp)
-	target_link_libraries(h5bench_openpmd_write openPMD hdf5 MPI::MPI_C)
+    add_executable(h5bench_openpmd_write openpmd/examples/8a_benchmark_write_parallel.cpp)
+    target_link_libraries(h5bench_openpmd_write openPMD hdf5 MPI::MPI_C)
 
-	set_target_properties(h5bench_openpmd_write PROPERTIES
-	    CXX_EXTENSIONS OFF
-	    CXX_STANDARD_REQUIRED ON
-	    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-	)
+    set_target_properties(h5bench_openpmd_write PROPERTIES
+        CXX_EXTENSIONS OFF
+        CXX_STANDARD_REQUIRED ON
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+    )
 
-	add_executable(h5bench_openpmd_read openpmd/examples/8b_benchmark_read_parallel.cpp)
-	target_link_libraries(h5bench_openpmd_read openPMD hdf5 MPI::MPI_C)
+    add_executable(h5bench_openpmd_read openpmd/examples/8b_benchmark_read_parallel.cpp)
+    target_link_libraries(h5bench_openpmd_read openPMD hdf5 MPI::MPI_C)
 
-	set_target_properties(h5bench_openpmd_read PROPERTIES
-	    CXX_EXTENSIONS OFF
-	    CXX_STANDARD_REQUIRED ON
-	    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-	)
+    set_target_properties(h5bench_openpmd_read PROPERTIES
+        CXX_EXTENSIONS OFF
+        CXX_STANDARD_REQUIRED ON
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+    )
 endif()
 
 configure_file(${CMAKE_SOURCE_DIR}/h5bench ${CMAKE_BINARY_DIR}/h5bench COPYONLY)
@@ -250,49 +250,49 @@ configure_file(${CMAKE_SOURCE_DIR}/h5bench ${CMAKE_BINARY_DIR}/h5bench COPYONLY)
 # Install binaries ############################################################
 
 install(
-	FILES
-	h5bench
-	PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
-	DESTINATION bin
+    FILES
+    h5bench
+    PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
+    DESTINATION bin
 )
 
 if(H5BENCH_EXERCISER)
-	install(
-		TARGETS
-		h5bench_exerciser 
-		DESTINATION bin
-	)
+    install(
+        TARGETS
+        h5bench_exerciser 
+        DESTINATION bin
+    )
 endif()
 
 if(H5BENCH_METADATA)
-	install(
-		TARGETS
-		h5bench_hdf5_iotest
-		DESTINATION bin
-	)
+    install(
+        TARGETS
+        h5bench_hdf5_iotest
+        DESTINATION bin
+    )
 endif()
 
 if(H5BENCH_OPENPMD)
-	install(
-		TARGETS
-		h5bench_openpmd_write
-		h5bench_openpmd_read
-		DESTINATION bin
-	)
+    install(
+        TARGETS
+        h5bench_openpmd_write
+        h5bench_openpmd_read
+        DESTINATION bin
+    )
 endif()
 
 if(H5BENCH_AMREX)
-	install(
-		TARGETS
-		h5bench_amrex_sync
-		DESTINATION bin
-	)
+    install(
+        TARGETS
+        h5bench_amrex_sync
+        DESTINATION bin
+    )
 
-	if(WITH_ASYNC_VOL)
-		install( 
-			TARGETS
-			h5bench_amrex_async 
-			DESTINATION bin
-		)
-	endif()
+    if(WITH_ASYNC_VOL)
+        install( 
+            TARGETS
+            h5bench_amrex_async 
+            DESTINATION bin
+        )
+    endif()
 endif()

--- a/docs/source/buildinstructions.rst
+++ b/docs/source/buildinstructions.rst
@@ -105,9 +105,9 @@ h5bench will automatically set the environment variables required to run the asy
 	export HDF5_VOL_CONNECTOR="async under_vol=0;under_info={}"
 	export HDF5_PLUGIN_PATH="$ASYNC_HOME"
 
-	// Linux
+	# Linux
 	export LD_LIBRARY_PATH="$HDF5_HOME/lib:$ASYNC_HOME"
-	// MacOS
+	# MacOS
 	export DYLD_LIBRARY_PATH="$HDF5_HOME/lib:$ASYNC_HOME"
 
 -----------------------------------

--- a/docs/source/buildinstructions.rst
+++ b/docs/source/buildinstructions.rst
@@ -5,10 +5,22 @@ Build Instructions
 Build with CMake (recommended)
 -----------------------------------
 
+First, clone the h5bench GitHub repository and ensure you are cloning the submodules:
+
+.. code-block:: bash
+
+	git clone --recurse-submodules https://github.com/hpc-io/h5bench
+
+If you are upadting your h5bench, ensure you have the latest submodules that could be included in new releases:
+
+.. code-block:: bash
+
+	git submodule update --init
+
 Dependency and environment variable settings
 ---------------------------------------------------
 
-H5bench depends on MPI and Parallel HDF5.
+H5bench depends on MPI and parallel HDF5.
 
 +++++++++++++++++++++++++++++++++
 Use system provided by HDF5 
@@ -26,55 +38,77 @@ You can also load any paralel HDF5 provided on your system, and you are good to 
 Use your own installed HDF5
 +++++++++++++++++++++++++++++++++
 
-Make sure to unload any system provided HDF5 version, and set an environment variable to specify the HDF5 install path:
+Make sure to unload any system provided HDF5 version:, and set an environment variable to specify the HDF5 install path:
 
 .. code-block:: bash
 
-	HDF5_HOME: the location you installed HDF5. It should point to a path that look like /path_to_my_hdf5_build/hdf5 and contains include/, lib/ and bin/ subdirectories.
+	export HDF5_HOME=/path/to/your/hdf5/installation
 
+It should point to a path that contains the ``include/``, ``lib/``, and ``bin/`` subdirectories.
 
 Compile with CMake
 ---------------------------------------------------
 
-Assume that the repo is cloned and now you are in the source directory h5bench, run the following simple steps:
+In the source directory of your cloned h5bench repository, run the following:
 
 .. code-block:: bash
 
 	mkdir build
 	cd build
+
 	cmake ..
+
 	make
 	make install
+
+By default, h5bench will only compile the base write and read benchmarks. To enable the additional benchmarks, you need to explicitly enable them before building h5bench. You can also enable all the benchmarks with ``-DH5BENCH_ALL=ON``. Notice that some of them have additional dependencies.
+
+==================== =========================== ===============================
+**Benchmark**        **Name**                    **Build**                     
+==================== =========================== ===============================
+h5bench write        ``h5bench_write``           Always   
+h5bench read         ``h5bench_read``            Always   
+Metadata Stress      ``h5bench_hdf5_iotest``     ``-DH5BENCH_METADATA=ON``
+AMReX                ``h5bench_amrex``           ``-DH5BENCH_AMREX=ON``   
+Exerciser            ``h5bench_exerciser``       ``-DH5BENCH_EXERCISER=ON``
+OpenPMD (write)      ``h5bench_openpmd_write``   ``-DH5BENCH_OPENPMD=ON``
+OpenPMD (read)       ``h5bench_openpmd_read``    ``-DH5BENCH_OPENPMD=ON``
+E3SM-IO              ``h5bench_e3sm``            ``-DH5BENCH_E3SM=ON`` 
+==================== =========================== ===============================
 
 .. warning::
 
 	If you want to specify the installation directory, you can pass ``-DCMAKE_INSTALL_PREFIX`` to ``cmake``. If you are not installing it, make sure when you run ``h5bench``, you update your environment variables to include the `build` directory. Otherwise, h5bench will not be able to find all the benchmarks.
 
-Build to run in async
+Build with HDF5 ASYNC VOL connector support
 ---------------------------------------------------
 
-To run h5bench_vpicio or h5bench_bdcatsio in async mode, you need the develop branchs of BOTH HDF5 and Async-VOL and build H5bench separately.
+To run ``_async`` benchmarks, you need the develop branch of **both** HDF5 and ASYNC-VOL. When building h5bench you need to specify the ``-DWITH_ASYNC_VOL:BOOL=ON`` option and have already compiled the VOL connector in the ``$ASYNC_VOL`` directory:
 
 .. code-block:: bash
 
 	mkdir build
 	cd build
-	cmake .. -DWITH_ASYNC_VOL:BOOL=ON -DCMAKE_C_FLAGS="-I/$YOUR_ASYNC_VOL/src -L/$YOUR_ASYNC_VOL/src"
+
+	cmake .. -DWITH_ASYNC_VOL=ON -DCMAKE_C_FLAGS="-I/$ASYNC_VOL/src -L/$ASYNC_VOL/src"
+
 	make
 	make install
 
-Necessary environment variable setting:
+h5bench will automatically set the environment variables required to run the asynchronous versions, as long as you specify them in your JSON configuration file. However, if you run the benchmarks manually, you will need to set the following environment variables:
 
 .. code-block:: bash
 
 	export HDF5_HOME="$YOUR_HDF5_DEVELOP_BRANCH_BUILD/hdf5"
 	export ASYNC_HOME="$YOUR_ASYNC_VOL/src"
+
 	export HDF5_VOL_CONNECTOR="async under_vol=0;under_info={}"
 	export HDF5_PLUGIN_PATH="$ASYNC_HOME"
+
+	// Linux
+	export LD_LIBRARY_PATH="$HDF5_HOME/lib:$ASYNC_HOME"
+	// MacOS
 	export DYLD_LIBRARY_PATH="$HDF5_HOME/lib:$ASYNC_HOME"
-
-
-And all the binaries will be built to the build/directory.
 
 -----------------------------------
 Build with Spack

--- a/h5bench
+++ b/h5bench
@@ -240,9 +240,8 @@ class H5bench:
             if 'path' in vol:
                 self.vol_environment['HDF5_PLUGIN_PATH'] += vol['path']
 
+                self.logger.info('HDF5_PLUGIN_PATH: %s', self.vol_environment['HDF5_PLUGIN_PATH'])
             self.vol_environment['ABT_THREAD_STACKSIZE'] = '100000'
-
-            self.logger.info('Environment: %s', self.vol_environment['LD_LIBRARY_PATH'])
 
     def enable_vol(self, vol):
         """Enable VOL by setting the connector."""

--- a/h5bench
+++ b/h5bench
@@ -245,7 +245,7 @@ class H5bench:
                 self.vol_environment['LD_LIBRARY_PATH'] += vol['library']
                 self.vol_environment['DYLD_LIBRARY_PATH'] += vol['library']
             if 'path' in vol:
-                self.vol_environment['HDF5_PLUGIN_PATH'] += vol['path']
+                self.vol_environment['HDF5_PLUGIN_PATH'] = vol['path']
 
             self.vol_environment['ABT_THREAD_STACKSIZE'] = '100000'
 

--- a/h5bench
+++ b/h5bench
@@ -6,6 +6,7 @@ import time
 import uuid
 import shlex
 import errno
+import distutils
 import argparse
 import collections
 import subprocess
@@ -381,8 +382,20 @@ class H5bench:
 
             exit(-1)
 
+    def is_available(self, executable):
+        """Check if binary is available."""
+        return distutils.spawn.find_executable(
+            executable,
+            path=os.environ['PATH'] + ':.'
+        )
+
     def run_exerciser(self, id, setup):
         """Run the exerciser benchmark."""
+        if not self.is_available(self.H5BENCH_EXERCISER):
+            self.logger.critical('{} is not available'.format(self.H5BENCH_EXERCISER))
+
+            return
+
         try:
             start = time.time()
 
@@ -432,6 +445,11 @@ class H5bench:
 
     def run_metadata(self, id, setup):
         """Run the metadata stress benchmark."""
+        if not self.is_available(self.H5BENCH_METADATA):
+            self.logger.critical('{} is not available'.format(self.H5BENCH_METADATA))
+
+            return
+
         try:
             start = time.time()
 
@@ -492,6 +510,11 @@ class H5bench:
 
     def run_amrex(self, id, setup, vol):
         """Run the AMReX benchmark."""
+        if not self.is_available(self.H5BENCH_AMREX_SYNC):
+            self.logger.critical('{} is not available'.format(self.H5BENCH_AMREX_SYNC))
+
+            return
+
         try:
             start = time.time()
 
@@ -568,6 +591,16 @@ class H5bench:
 
     def run_openpmd(self, id, setup):
         """Run the OpenPMD kernel benchmark."""
+        if not self.is_available(self.H5BENCH_OPENPMD_WRITE):
+            self.logger.critical('{} is not available'.format(self.H5BENCH_OPENPMD_WRITE))
+
+            return
+
+        if not self.is_available(self.H5BENCH_OPENPMD_READ):
+            self.logger.critical('{} is not available'.format(self.H5BENCH_OPENPMD_READ))
+
+            return
+
         try:
             start = time.time()
 
@@ -643,6 +676,11 @@ class H5bench:
 
     def run_e3sm(self, id, setup):
         """Run the E3SM benchmark."""
+        if not self.is_available(self.H5BENCH_E3SM):
+            self.logger.critical('{} is not available'.format(self.H5BENCH_E3SM))
+
+            return
+
         try:
             start = time.time()
 

--- a/h5bench
+++ b/h5bench
@@ -240,8 +240,10 @@ class H5bench:
             if 'path' in vol:
                 self.vol_environment['HDF5_PLUGIN_PATH'] += vol['path']
 
-                self.logger.info('HDF5_PLUGIN_PATH: %s', self.vol_environment['HDF5_PLUGIN_PATH'])
             self.vol_environment['ABT_THREAD_STACKSIZE'] = '100000'
+
+            if 'HDF5_PLUGIN_PATH' in vol:
+                self.logger.info('HDF5_PLUGIN_PATH: %s', self.vol_environment['HDF5_PLUGIN_PATH'])
 
     def enable_vol(self, vol):
         """Enable VOL by setting the connector."""

--- a/h5bench
+++ b/h5bench
@@ -242,8 +242,14 @@ class H5bench:
 
             self.vol_environment['ABT_THREAD_STACKSIZE'] = '100000'
 
-            if 'HDF5_PLUGIN_PATH' in vol:
-                self.logger.info('HDF5_PLUGIN_PATH: %s', self.vol_environment['HDF5_PLUGIN_PATH'])
+            if 'HDF5_PLUGIN_PATH' in self.vol_environment:
+                self.logger.debug('HDF5_PLUGIN_PATH: %s', self.vol_environment['HDF5_PLUGIN_PATH'])
+
+        if 'LD_LIBRARY_PATH' in self.vol_environment:
+            self.logger.debug('LD_LIBRARY_PATH: %s', self.vol_environment['LD_LIBRARY_PATH'])
+
+        if 'DYLD_LIBRARY_PATH' in self.vol_environment:
+            self.logger.debug('DYLD_LIBRARY_PATH: %s', self.vol_environment['DYLD_LIBRARY_PATH'])
 
     def enable_vol(self, vol):
         """Enable VOL by setting the connector."""

--- a/h5bench
+++ b/h5bench
@@ -235,6 +235,12 @@ class H5bench:
         """Prepare the environment variables for the VOL."""
 
         if vol is not None:
+            if 'LD_LIBRARY_PATH' not in self.vol_environment:
+                self.vol_environment['LD_LIBRARY_PATH'] = ''
+
+            if 'DYLD_LIBRARY_PATH' not in self.vol_environment:
+                self.vol_environment['DYLD_LIBRARY_PATH'] = ''
+
             if 'library' in vol:
                 self.vol_environment['LD_LIBRARY_PATH'] += vol['library']
                 self.vol_environment['DYLD_LIBRARY_PATH'] += vol['library']

--- a/h5bench
+++ b/h5bench
@@ -235,14 +235,14 @@ class H5bench:
 
         if vol is not None:
             if 'library' in vol:
-                self.logger.info('Environment: %s', vol['library'])
-
-                self.vol_environment['LD_LIBRARY_PATH'] = vol['library']
-                self.vol_environment['DYLD_LIBRARY_PATH'] = vol['library']
+                self.vol_environment['LD_LIBRARY_PATH'] += vol['library']
+                self.vol_environment['DYLD_LIBRARY_PATH'] += vol['library']
             if 'path' in vol:
-                self.vol_environment['HDF5_PLUGIN_PATH'] = vol['path']
+                self.vol_environment['HDF5_PLUGIN_PATH'] += vol['path']
 
             self.vol_environment['ABT_THREAD_STACKSIZE'] = '100000'
+
+            self.logger.info('Environment: %s', self.vol_environment['LD_LIBRARY_PATH'])
 
     def enable_vol(self, vol):
         """Enable VOL by setting the connector."""

--- a/spack/packages/h5bench/package.py
+++ b/spack/packages/h5bench/package.py
@@ -1,0 +1,52 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class H5bench(CMakePackage):
+    """A benchmark suite for measuring HDF5 performance."""
+
+    homepage = 'https://github.com/hpc-io/h5bench'
+    git      = 'https://github.com/hpc-io/h5bench.git'
+
+    maintainers = ['jeanbez', 'sbyna']
+
+    version('master', branch='master', submodules=True)
+    version('develop', branch='develop', submodules=True)
+
+    version('1.2', tag='1.2', submodules=True)
+    version('1.1', tag='1.1', submodules=True, depecrated=True)
+    version('1.0', tag='1.0', submodules=True, depecrated=True)
+
+    variant('async', default=False, description='Enable the HDF5 VOL-ASYNC connector support')
+
+    depends_on('cmake@3.10:', type='build')
+    depends_on('mpi')
+    depends_on('hdf5@develop-1.13 +mpi +threadsafe')
+    depends_on('hdf5-vol-async@test', when='+async')
+
+    def setup_build_environment(self, env):
+        env.set('HDF5_HOME', self.spec['hdf5'].prefix)
+        
+        if '+async' in self.spec:
+            env.set('ASYNC_HOME', self.spec['hdf5-vol-async'].prefix)
+
+    def setup_run_environment(self, env):
+        env.set('HDF5_HOME', self.spec['hdf5'].prefix)
+
+        if '+async' in self.spec:
+            env.set('ASYNC_HOME', self.spec['hdf5-vol-async'].prefix)
+            env.set('HDF5_PLUGIN_PATH', self.spec['hdf5-vol-async'].prefix.lib)
+
+    def cmake_args(self):
+        args = []
+
+        if '+async' in self.spec:
+            args.append('-DWITH_ASYNC_VOL:BOOL=ON')
+
+        args.append('-DCMAKE_C_COMPILER=h5pcc')
+
+        return args

--- a/spack/repo.yaml
+++ b/spack/repo.yaml
@@ -1,0 +1,2 @@
+repo:
+  namespace: 'h5bench'


### PR DESCRIPTION
By default, h5bench will only compile the base benchmarks as some new benchmarks that are being included in the suite have additional software dependencies. This PR gives more control over which additional benchmarks should be compiled (or all of them at once).