### PR TITLE
Fix compilation for new GCC versions

### DIFF
--- a/commons/h5bench_util.c
+++ b/commons/h5bench_util.c
@@ -29,6 +29,8 @@ int str_to_ull(char *str_in, unsigned long long *num_out);
 int parse_time(char *str_in, duration *time);
 int parse_unit(char *str_in, unsigned long long *num, char **unit_str);
 
+int has_vol_async;
+
 unsigned long
 get_time_usec()
 {

--- a/commons/h5bench_util.h
+++ b/commons/h5bench_util.h
@@ -193,7 +193,7 @@ void print_params(const bench_params *p);
 void bench_params_free(bench_params *p);
 int  has_vol_connector();
 
-int has_vol_async;
+extern int has_vol_async;
 
 int   file_create_try(const char *path);
 int   file_exist(const char *path);


### PR DESCRIPTION
Fix compilation for new GCC 11 errors where we require `extern` for the variable `has_vol_async`.