### PR TITLE
pass gpfs align settings as a configuration parameter for h5bench

### DIFF
--- a/commons/h5bench_util.c
+++ b/commons/h5bench_util.c
@@ -910,29 +910,28 @@ _set_params(char *key, char *val_in, bench_params *params_in_out, int do_write)
             (*params_in_out).subfiling = 0;
     }
     else if (strcmp(key, "ALIGN") == 0) {
-        int align = atoi(val);
-        if (align == 0 || align == 1)
-            (*params_in_out).align = align;
+        if (val[0] == 'Y' || val[0] == 'y') {
+            (*params_in_out).align = 1;
+        }
         else {
-            printf("ALIGN MUST BE 1 OR 0\n");
-            return -1;
+            (*params_in_out).align = 0;
         }
     }
     else if (strcmp(key, "ALIGN_THRESHOLD") == 0) {
         int align_threshold = atoi(val);
-        if (align_threshold >=0)
+        if (align_threshold >= 0)
             (*params_in_out).align_threshold = align_threshold;
         else {
-            printf("align_threshold >=0 \n");
+            printf("ALIGN_THRESHOLD must be >=0\n");
             return -1;
         }
     }
     else if (strcmp(key, "ALIGN_LEN") == 0) {
         int align_len = atoi(val);
-        if (align_len >=0)
+        if (align_len >= 0)
             (*params_in_out).align_len = align_len;
         else {
-            printf("ALIGN_LEN >=0 \n");
+            printf("ALIGN_LEN must be >=0\n");
             return -1;
         }
     }
@@ -988,13 +987,13 @@ bench_params_init(bench_params *params_out)
     (*params_out).csv_path      = NULL;
     (*params_out).env_meta_path = NULL;
 
-    (*params_out).csv_path      = NULL;
-    (*params_out).csv_fs        = NULL;
-    (*params_out).env_meta_path = NULL;
-    (*params_out).file_per_proc = 0;
-    (*params_out).align         = 0;
-    (*params_out).align_threshold       = 0;
-    (*params_out).align_len     = 0;
+    (*params_out).csv_path        = NULL;
+    (*params_out).csv_fs          = NULL;
+    (*params_out).env_meta_path   = NULL;
+    (*params_out).file_per_proc   = 0;
+    (*params_out).align           = 0;
+    (*params_out).align_threshold = 0;
+    (*params_out).align_len       = 0;
 }
 
 int
@@ -1152,9 +1151,12 @@ print_params(const bench_params *p)
             printf("    chunk_dim3: %lu\n", p->chunk_dim_3);
         }
     }
-    printf("From h5bench_util.c - ALIGN : %d \t ALIGN_THRESHOLD : %ld \t ALIGN_LEN : %ld \t \n", 
-            p->align, p->align_threshold, p->align_len);
-
+    if (p->align) {
+        printf("Align settings: \n");
+        printf("    align  = %d\n", p->align);
+        printf("    align threshold = %ld\n", p->align_threshold);
+        printf("    align length = %ld\n", p->align_len);
+    }
     printf("===========================================================\n");
     printf("\n");
 }

--- a/commons/h5bench_util.c
+++ b/commons/h5bench_util.c
@@ -909,6 +909,33 @@ _set_params(char *key, char *val_in, bench_params *params_in_out, int do_write)
         else
             (*params_in_out).subfiling = 0;
     }
+    else if (strcmp(key, "ALIGN") == 0) {
+        int align = atoi(val);
+        if (align == 0 || align == 1)
+            (*params_in_out).align = align;
+        else {
+            printf("ALIGN MUST BE 1 OR 0\n");
+            return -1;
+        }
+    }
+    else if (strcmp(key, "ALIGN_THRESHOLD") == 0) {
+        int align_threshold = atoi(val);
+        if (align_threshold >=0)
+            (*params_in_out).align_threshold = align_threshold;
+        else {
+            printf("align_threshold >=0 \n");
+            return -1;
+        }
+    }
+    else if (strcmp(key, "ALIGN_LEN") == 0) {
+        int align_len = atoi(val);
+        if (align_len >=0)
+            (*params_in_out).align_len = align_len;
+        else {
+            printf("ALIGN_LEN >=0 \n");
+            return -1;
+        }
+    }
     else {
         printf("Unknown Parameter: %s\n", key);
         return -1;
@@ -965,6 +992,9 @@ bench_params_init(bench_params *params_out)
     (*params_out).csv_fs        = NULL;
     (*params_out).env_meta_path = NULL;
     (*params_out).file_per_proc = 0;
+    (*params_out).align         = 0;
+    (*params_out).align_threshold       = 0;
+    (*params_out).align_len     = 0;
 }
 
 int
@@ -1122,6 +1152,9 @@ print_params(const bench_params *p)
             printf("    chunk_dim3: %lu\n", p->chunk_dim_3);
         }
     }
+    printf("From h5bench_util.c - ALIGN : %d \t ALIGN_THRESHOLD : %ld \t ALIGN_LEN : %ld \t \n", 
+            p->align, p->align_threshold, p->align_len);
+
     printf("===========================================================\n");
     printf("\n");
 }

--- a/commons/h5bench_util.h
+++ b/commons/h5bench_util.h
@@ -127,6 +127,9 @@ typedef struct bench_params {
     char *        env_meta_path;
     FILE *        csv_fs;
     int           file_per_proc;
+    int           align;
+    unsigned long align_threshold;
+    unsigned long align_len;
 } bench_params;
 
 typedef struct data_md {

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -166,6 +166,35 @@ This way, you can configure a workflow with multiple interleaving files, e.g., `
       }
    }
 
+You can also provide the ``align`` settings for GPFS filesystem in the ``benchmark`` property configuration. Note, not in the ``filesystem`` property.  
+This parameter is enabled only for h5bench-write and h5bench-write-unlimited.
+
+
+.. code-block::
+
+   {
+      "benchmark": "write",
+      "file": "test.h5",
+      "configuration": {
+            "MEM_PATTERN": "CONTIG",
+            "FILE_PATTERN": "CONTIG",
+            "TIMESTEPS": "5",
+            "DELAYED_CLOSE_TIMESTEPS": "2",
+            "COLLECTIVE_DATA": "YES",
+            "COLLECTIVE_METADATA": "YES",
+            "EMULATED_COMPUTE_TIME_PER_TIMESTEP": "1 s", 
+            "NUM_DIMS": "1",
+            "DIM_1": "4194304",
+            "DIM_2": "1",
+            "DIM_3": "1",
+            "MODE": "ASYNC",
+            "CSV_FILE": "output.csv",
+            "ALIGN":"YES",
+            "ALIGN_THRESHOLD":"16777216",
+            "ALIGN_LEN":"16777216"
+      }
+   }
+
 For the ``metadata`` stress benchmark, ``file`` and ``configuration`` properties must be defined:
 
 .. code-block::

--- a/h5bench_patterns/h5bench_write.c
+++ b/h5bench_patterns/h5bench_write.c
@@ -910,19 +910,18 @@ set_metadata(hid_t fapl, int align, unsigned long threshold, unsigned long align
 {
     hsize_t threshold_o, alignment_len_o;
     herr_t  ret;
-    if (align == 1)
-    {
+    if (align == 1) {
         H5Pset_alignment(fapl, threshold, alignment_len);
 
         ret = H5Pget_alignment(fapl, &threshold_o, &alignment_len_o);
         if (ret < 0)
-            if (MY_RANK == 0) 
-                printf("K-Debug: H5Pget_alignment failed \n");
-        
-        if (MY_RANK == 0) 
-        {
-            printf("K-Debug: alignment_len_o Value:  %ld\n", alignment_len_o );
-            printf("K-Debug: threshold_o Value:  %ld\n", threshold_o );  
+            if (MY_RANK == 0)
+                printf("H5Pget_alignment failed \n");
+
+        if (MY_RANK == 0) {
+            printf("GPFS alignment settings: ON\n");
+            printf("Value of alignment length :  %ld\n", alignment_len_o);
+            printf("Value of alignment threshold :  %ld\n", threshold_o);
         }
     }
     if (meta_collective == 1) {
@@ -1062,7 +1061,7 @@ main(int argc, char *argv[])
     if (MY_RANK == 0)
         printf("Total number of particles: %lldM\n", TOTAL_PARTICLES / (M_VAL));
 
-    hid_t fapl = set_fapl();
+    hid_t fapl      = set_fapl();
     ALIGN           = params.align;
     ALIGN_THRESHOLD = params.align_threshold;
     ALIGN_LEN       = params.align_len;
@@ -1200,19 +1199,6 @@ main(int argc, char *argv[])
             fprintf(params.csv_fs, "observed time, %.3f, %s\n", oct_s, "seconds");
             fclose(params.csv_fs);
         }
-
-        if (MY_RANK == 0) {
-        printf("K-DEBUG-Summary\n");
-        printf("Number of ranks: %d \n", NUM_RANKS);
-        printf("Number of TIMESTEPS: %d \n", NUM_TIMESTEPS);
-        printf("NUM_PARTICLES per rank: %llu \n", NUM_PARTICLES);
-        printf("TOTAL_PARTICLES from all ranks: %llu \n", TOTAL_PARTICLES);
-        printf("Size of 1 particle: %ld Bytes\n", (7 * sizeof(float) + sizeof(int)));
-        printf("total_write_size: %lu Bytes\n", total_write_size);
-        
-        //unsigned long total_write_size = NUM_RANKS * NUM_TIMESTEPS * NUM_PARTICLES * (7 * sizeof(float) + sizeof(int));
-    }
-
     }
 
     MPI_Finalize();

--- a/samples/async-write-1d-contig-contig-gpfs-align.json
+++ b/samples/async-write-1d-contig-contig-gpfs-align.json
@@ -1,11 +1,13 @@
 {
     "mpi": {
-        "command": "jsrun",
-        "ranks": "64",
-        "configuration": "-a 16 -c 16 -r 1"
+        "command": "mpirun",
+        "ranks": "4",
+        "configuration": "--allow-run-as-root --np 2 --oversubscribe"
     },
-    "vol": { },
-    "file-system": { },
+    "vol": {
+    },
+    "file-system": {
+    },
     "directory": "storage",
     "benchmarks": [
         {
@@ -25,7 +27,7 @@
                 "DIM_3": "1",
                 "CSV_FILE": "output.csv",
                 "MODE": "ASYNC",
-                "ALIGN":"1",
+                "ALIGN":"YES",
                 "ALIGN_THRESHOLD":"16777216",
                 "ALIGN_LEN":"16777216"
             }

--- a/samples/async-write-1d-contig-contig-gpfs-align.json
+++ b/samples/async-write-1d-contig-contig-gpfs-align.json
@@ -1,0 +1,34 @@
+{
+    "mpi": {
+        "command": "jsrun",
+        "ranks": "64",
+        "configuration": "-a 16 -c 16 -r 1"
+    },
+    "vol": { },
+    "file-system": { },
+    "directory": "storage",
+    "benchmarks": [
+        {
+            "benchmark": "write",
+            "file": "test.h5",
+            "configuration": {
+                "MEM_PATTERN": "CONTIG",
+                "FILE_PATTERN": "CONTIG",
+                "TIMESTEPS": "5",
+                "DELAYED_CLOSE_TIMESTEPS": "2",
+                "COLLECTIVE_DATA": "YES",
+                "COLLECTIVE_METADATA": "YES",
+                "EMULATED_COMPUTE_TIME_PER_TIMESTEP": "1 s", 
+                "NUM_DIMS": "1",
+                "DIM_1": "4194304",
+                "DIM_2": "1",
+                "DIM_3": "1",
+                "CSV_FILE": "output.csv",
+                "MODE": "ASYNC",
+                "ALIGN":"1",
+                "ALIGN_THRESHOLD":"16777216",
+                "ALIGN_LEN":"16777216"
+            }
+        }
+    ]
+}

--- a/src/h5bench.py
+++ b/src/h5bench.py
@@ -202,9 +202,12 @@ class H5bench:
                     continue
 
             id = str(uuid.uuid4()).split('-')[0]
-
+            cobalt_jobid = os.environ['LSB_JOBID']
+            id = id + "--" + cobalt_jobid
+            self.logger.info('LSB_JOBID is [{}]'.format(cobalt_jobid))
             self.logger.info('h5bench [{}] - Starting'.format(name))
             self.logger.info('h5bench [{}] - DIR: {}/{}/'.format(name, setup['directory'], id))
+            #print(f"storage ID is {id} and LSB_JOBID is {cobalt_jobid}\n")
 
             os.mkdir('{}/{}'.format(setup['directory'], id))
 
@@ -235,9 +238,13 @@ class H5bench:
             self.mpi = '{} {}'.format(mpi['command'], mpi['configuration'])
         else:
             if mpi['command'] in ['mpirun', 'mpiexec']:
-                self.mpi = '{} -np {}'.format(mpi['command'], mpi['ranks'])
+                self.mpi = '{} -n {} -ppn {}'.format(mpi['command'], mpi['ranks'], mpi['ppn'])
             elif mpi['command'] == 'srun':
                 self.mpi = '{} --cpu_bind=cores -n {}'.format(mpi['command'], mpi['ranks'])
+            elif mpi['command'] == 'aprun':
+                self.mpi = '{} -n {} -N {} -cc depth'.format(mpi['command'], mpi['ranks'], mpi['ppn'])  
+            elif mpi['command'] == 'jsrun':
+                self.mpi = '{} -n {} -r {} -cc depth'.format(mpi['command'], mpi['ranks'], mpi['ppn'])  
             else:
                 self.logger.warning('Unknown MPI launcher selected!')
 

--- a/src/h5bench.py
+++ b/src/h5bench.py
@@ -202,12 +202,23 @@ class H5bench:
                     continue
 
             id = str(uuid.uuid4()).split('-')[0]
-            cobalt_jobid = os.environ['LSB_JOBID']
-            id = id + "--" + cobalt_jobid
-            self.logger.info('LSB_JOBID is [{}]'.format(cobalt_jobid))
+            if 'SLURM_JOB_ID' in os.environ:
+                jobid = os.environ['SLURM_JOB_ID'] # nersc
+            elif  'COBALT_JOBID' in os.environ:
+                jobid = os.environ['COBALT_JOBID'] # alcf_theta
+            elif  'PBS_JOBID' in os.environ:
+                jobid = os.environ['PBS_JOBID']    # alcf_polaris
+            elif  'LSB_JOBID' in os.environ:
+                jobid = os.environ['LSB_JOBID']    # olcf
+            else:
+                jobid = None
+            
+            if jobid is not None:
+                id = id + "-" + jobid
+                self.logger.info('JOBID is [{}]'.format(jobid))
+            
             self.logger.info('h5bench [{}] - Starting'.format(name))
             self.logger.info('h5bench [{}] - DIR: {}/{}/'.format(name, setup['directory'], id))
-            #print(f"storage ID is {id} and LSB_JOBID is {cobalt_jobid}\n")
 
             os.mkdir('{}/{}'.format(setup['directory'], id))
 
@@ -238,13 +249,9 @@ class H5bench:
             self.mpi = '{} {}'.format(mpi['command'], mpi['configuration'])
         else:
             if mpi['command'] in ['mpirun', 'mpiexec']:
-                self.mpi = '{} -n {} -ppn {}'.format(mpi['command'], mpi['ranks'], mpi['ppn'])
+                self.mpi = '{} -np {}'.format(mpi['command'], mpi['ranks'])
             elif mpi['command'] == 'srun':
                 self.mpi = '{} --cpu_bind=cores -n {}'.format(mpi['command'], mpi['ranks'])
-            elif mpi['command'] == 'aprun':
-                self.mpi = '{} -n {} -N {} -cc depth'.format(mpi['command'], mpi['ranks'], mpi['ppn'])  
-            elif mpi['command'] == 'jsrun':
-                self.mpi = '{} -n {} -r {} -cc depth'.format(mpi['command'], mpi['ranks'], mpi['ppn'])  
             else:
                 self.logger.warning('Unknown MPI launcher selected!')
 

--- a/src/h5bench.py
+++ b/src/h5bench.py
@@ -215,7 +215,7 @@ class H5bench:
             
             if jobid is not None:
                 id = id + "-" + jobid
-                self.logger.info('JOBID is [{}]'.format(jobid))
+                self.logger.info('JOBID: {}'.format(jobid))
             
             self.logger.info('h5bench [{}] - Starting'.format(name))
             self.logger.info('h5bench [{}] - DIR: {}/{}/'.format(name, setup['directory'], id))


### PR DESCRIPTION
This PR provides the following features for h5bench
1. Allows the ability to pass alignment yes/no, alignment length and alignment threshold for GPFS as a configuration parameter. 
2. Provided an example with sample configuration file for summit-GPFS.
3. Validates H5Pset_alignment through H5Pget_alignment.
4. Appends jobID with the current runID in the output folder. This helps to easily identify your output folder especially if you have large number of output runs. Added support for all nersc,alcf and olcf schedulers. In case of local runs (without schedulers), the user will not see any difference and defaults to just current runID. 