### PR TITLE
Fix the test name executable for normal dist test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,8 +125,8 @@ endif()
 
 set(h5bench_write_normal_dist_src h5bench_patterns/h5bench_write_normal_dist.c)
 
-add_executable(h5bench_write_normal_dist ${h5bench_write_normal_dist_src})
-target_link_libraries(h5bench_write_normal_dist h5bench_util hdf5 z m ${CMAKE_DL_LIBS} MPI::MPI_C) 
+add_executable(h5bench_write_var_normal_dist ${h5bench_write_normal_dist_src})
+target_link_libraries(h5bench_write_var_normal_dist h5bench_util hdf5 z m ${CMAKE_DL_LIBS} MPI::MPI_C) 
 
 # h5bench WRITE ###############################################################
 #
@@ -355,7 +355,7 @@ install(
     TARGETS
     h5bench_write
     h5bench_write_unlimited
-    h5bench_write_normal_dist
+    h5bench_write_var_normal_dist
     h5bench_overwrite
     h5bench_append
     h5bench_read


### PR DESCRIPTION
The h5bench.py and documenation name and reference this test as h5bench_write_var_normal_dist but the compiled target is missing the "var" substring so the test is not callable from a json config file.
Fixing the binary name aligns the test with its expected calling convention.