### PR TITLE
Update the github acttions to resove errors

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run clang-format style check for C programs.
-      uses: DoozyX/clang-format-lint-action@v0.11
+      uses: DoozyX/clang-format-lint-action@v0.18.2
       with:
         source: '.'
         extensions: 'c,h,cpp,hpp'

--- a/.github/workflows/clang-format-fix.yml
+++ b/.github/workflows/clang-format-fix.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run clang-format style check for C programs.
-      uses: DoozyX/clang-format-lint-action@v0.11
+      uses: DoozyX/clang-format-lint-action@v0.18.2
       with:
         source: '.'
         extensions: 'c,h,cpp,hpp'

--- a/.github/workflows/h5bench-hdf5-1.10.4.yml
+++ b/.github/workflows/h5bench-hdf5-1.10.4.yml
@@ -223,7 +223,7 @@ jobs:
 
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test
           path: build/storage/**/std*

--- a/.github/workflows/h5bench-hdf5-1.10.7.yml
+++ b/.github/workflows/h5bench-hdf5-1.10.7.yml
@@ -223,7 +223,7 @@ jobs:
 
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test
           path: build/h5bench_e3sm-prefix/src/h5bench_e3sm-stamp/*

--- a/.github/workflows/h5bench-hdf5-1.10.8.yml
+++ b/.github/workflows/h5bench-hdf5-1.10.8.yml
@@ -223,7 +223,7 @@ jobs:
 
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test
           path: build/storage/**/std*

--- a/.github/workflows/h5bench-hdf5-1.12.0.yml
+++ b/.github/workflows/h5bench-hdf5-1.12.0.yml
@@ -258,7 +258,7 @@ jobs:
 
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test
           path: build/storage/**/std*

--- a/.github/workflows/h5bench-hdf5-1.14.0.yml
+++ b/.github/workflows/h5bench-hdf5-1.14.0.yml
@@ -513,7 +513,7 @@ jobs:
 
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test
           path: build*/storage/**/std*

--- a/.github/workflows/h5bench-hdf5-1.14.1.yml
+++ b/.github/workflows/h5bench-hdf5-1.14.1.yml
@@ -513,7 +513,7 @@ jobs:
 
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test
           path: build*/storage/**/std*

--- a/.github/workflows/h5bench-hdf5-develop-test.yml
+++ b/.github/workflows/h5bench-hdf5-develop-test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   h5bench:
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 90
     env:
       OMPI_ALLOW_RUN_AS_ROOT: 1
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1

--- a/.github/workflows/h5bench-hdf5-develop-test.yml
+++ b/.github/workflows/h5bench-hdf5-develop-test.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test
           path: build*/storage/**/std*

--- a/.github/workflows/h5bench-hdf5-develop-test.yml
+++ b/.github/workflows/h5bench-hdf5-develop-test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   h5bench:
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 75
     env:
       OMPI_ALLOW_RUN_AS_ROOT: 1
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1

--- a/.github/workflows/h5bench-hdf5-develop.yml
+++ b/.github/workflows/h5bench-hdf5-develop.yml
@@ -645,7 +645,7 @@ jobs:
 
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test
           path: build*/storage/**/std*


### PR DESCRIPTION
Change action/artifacts-upload from v2 to v4 to remove dependence on deprecated v2.
The v4 syntax for the artifact-upload remains the same so a simple update of the version number should be sufficient.

See blog post for details:

https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

Also update clang-format container version to resolve dependency errors during container run.