### PR TITLE
Move output.csv file open to the the main function and limit to rank 0

### DIFF
--- a/commons/h5bench_util.c
+++ b/commons/h5bench_util.c
@@ -1049,9 +1049,6 @@ _set_params(char *key, char *val_in, bench_params *params_in_out, int do_write)
         (*params_in_out).asyncMode = MODE_SYNC;
     }
 
-    if ((*params_in_out).useCSV)
-        (*params_in_out).csv_fs = csv_init(params_in_out->csv_path, params_in_out->env_meta_path);
-
     if (val)
         free(val);
     return 1;

--- a/h5bench_patterns/h5bench_write.c
+++ b/h5bench_patterns/h5bench_write.c
@@ -1012,6 +1012,10 @@ main(int argc, char *argv[])
         return 0;
     }
 
+    if (MY_RANK == 0)
+	if (params.useCSV)
+	    params.csv_fs = csv_init(params.csv_path, params.env_meta_path);
+
     if (params.io_op != IO_WRITE) {
         if (MY_RANK == 0)
             printf("Make sure the configuration file has IO_OPERATION=WRITE defined\n");

--- a/h5bench_patterns/h5bench_write_normal_dist.c
+++ b/h5bench_patterns/h5bench_write_normal_dist.c
@@ -1050,6 +1050,10 @@ main(int argc, char *argv[])
         return 0;
     }
 
+    if (MY_RANK == 0)
+        if (params.useCSV)
+            params.csv_fs = csv_init(params.csv_path, params.env_meta_path);
+
     if (params.io_op != IO_WRITE) {
         if (MY_RANK == 0)
             printf("Make sure the configuration file has IO_OPERATION=WRITE defined\n");


### PR DESCRIPTION
This avoids opening the file in all ranks, causing file open contention between ranks.  Contention increases with rank count and stripe count.

Proposed partial fix for hpc-io/h5bench#131 for base write benchmarks.