### PR TITLE
Read write per timestep timing

### DIFF
--- a/commons/h5bench_util.c
+++ b/commons/h5bench_util.c
@@ -175,7 +175,7 @@ ts_delayed_close(mem_monitor *mon, unsigned long *metadata_time_total, int dset_
     if (!mon || !metadata_time_total)
         return -1;
 
-    time_step *   ts_run;
+    time_step    *ts_run;
     size_t        num_in_progress;
     H5ES_status_t op_failed;
     unsigned long t1, t2;
@@ -212,7 +212,7 @@ mem_monitor_check_run(mem_monitor *mon, unsigned long *metadata_time_total, unsi
         return -1;
     if (!has_vol_async)
         return 0;
-    time_step *   ts_run;
+    time_step    *ts_run;
     size_t        num_in_progress;
     hbool_t       op_failed;
     unsigned long t1, t2, t3, t4;
@@ -248,14 +248,23 @@ mem_monitor_check_run(mem_monitor *mon, unsigned long *metadata_time_total, unsi
     return 0;
 }
 
+/**
+ * data_wait_time_per_step, metadata_wait_time_per_step can
+ * safely but set to NULL if info is not needed.
+ */
 int
-mem_monitor_final_run(mem_monitor *mon, unsigned long *metadata_time_total, unsigned long *data_time_total)
+mem_monitor_final_run(mem_monitor *mon, unsigned long *metadata_time_total, unsigned long *data_time_total,
+                      unsigned long *data_wait_time_per_step, unsigned long *metadata_wait_time_per_step)
 {
+    if (metadata_wait_time_per_step != NULL)
+        memset(metadata_wait_time_per_step, 0, mon->time_step_cnt * sizeof(unsigned long));
+    if (data_wait_time_per_step)
+        memset(data_wait_time_per_step, 0, mon->time_step_cnt * sizeof(unsigned long));
     *metadata_time_total = 0;
     *data_time_total     = 0;
     size_t        num_in_progress;
     hbool_t       op_failed;
-    time_step *   ts_run;
+    time_step    *ts_run;
     unsigned long t1, t2, t3, t4, t5, t6;
     unsigned long meta_time = 0, data_time = 0;
     int           dset_cnt = 8;
@@ -292,7 +301,6 @@ mem_monitor_final_run(mem_monitor *mon, unsigned long *metadata_time_total, unsi
             ts_run->status = TS_READY;
         }
     }
-
     t2 = get_time_usec();
     meta_time += (t2 - t1);
 
@@ -317,6 +325,10 @@ mem_monitor_final_run(mem_monitor *mon, unsigned long *metadata_time_total, unsi
 
             t6 = get_time_usec();
 
+            if (metadata_wait_time_per_step != NULL)
+                metadata_wait_time_per_step[i] = ((t2 - t1) + (t4 - t3));
+            if (data_wait_time_per_step != NULL)
+                data_wait_time_per_step[i] = (t3 - t2);
             meta_time += ((t2 - t1) + (t4 - t3));
             data_time += (t3 - t2);
             ts_run->status = TS_DONE;
@@ -439,7 +451,7 @@ parse_time(char *str_in, duration *time)
     if (!time)
         time = calloc(1, sizeof(duration));
     unsigned long long num = 0;
-    char *             unit_str;
+    char              *unit_str;
     parse_unit(str_in, &num, &unit_str);
 
     if (!unit_str)
@@ -470,7 +482,7 @@ str_to_ull(char *str_in, unsigned long long *num_out)
         return -1;
     }
     unsigned long long num = 0;
-    char *             unit_str;
+    char              *unit_str;
     int                ret = parse_unit(str_in, &num, &unit_str);
     if (ret < 0)
         return -1;

--- a/commons/h5bench_util.h
+++ b/commons/h5bench_util.h
@@ -102,8 +102,8 @@ typedef struct bench_params {
     } access_pattern;
 
     // write_pattern bench_pattern;
-    char *             data_file_path;
-    char *             pattern_name;
+    char              *data_file_path;
+    char              *pattern_name;
     int                meta_coll; // for write only, metadata collective
     int                data_coll; // data collective
     int                cnt_time_step;
@@ -123,9 +123,9 @@ typedef struct bench_params {
     unsigned long chunk_dim_1;
     unsigned long chunk_dim_2;
     unsigned long chunk_dim_3;
-    char *        csv_path;
-    char *        env_meta_path;
-    FILE *        csv_fs;
+    char         *csv_path;
+    char         *env_meta_path;
+    FILE         *csv_fs;
     int           file_per_proc;
     int           align;
     unsigned long align_threshold;
@@ -136,10 +136,10 @@ typedef struct bench_params {
 typedef struct data_md {
     unsigned long long particle_cnt;
     unsigned long long dim_1, dim_2, dim_3;
-    float *            x, *y, *z;
-    float *            px, *py, *pz;
-    int *              id_1;
-    float *            id_2;
+    float             *x, *y, *z;
+    float             *px, *py, *pz;
+    int               *id_1;
+    float             *id_2;
 } data_contig_md;
 
 typedef struct csv_hanle {
@@ -166,7 +166,7 @@ typedef struct mem_monitor {
     unsigned long long mem_used;
     unsigned long long mem_threshold;
     async_mode         mode;
-    time_step *        time_steps;
+    time_step         *time_steps;
 } mem_monitor;
 
 unsigned long long read_time_val(duration time, time_unit unit);
@@ -183,7 +183,8 @@ int          ts_delayed_close(mem_monitor *mon, unsigned long *metadata_time_tot
 int          mem_monitor_check_run(mem_monitor *mon, unsigned long *metadata_time_total,
                                    unsigned long *data_time_total);
 int          mem_monitor_final_run(mem_monitor *mon, unsigned long *metadata_time_total,
-                                   unsigned long *data_time_total);
+                                   unsigned long *data_time_total, unsigned long *data_wait_time_per_step,
+                                   unsigned long *metadata_wait_time_per_step);
 // Uniform random number
 float uniform_random_number();
 

--- a/h5bench_patterns/h5bench_append.c
+++ b/h5bench_patterns/h5bench_append.c
@@ -33,7 +33,7 @@ hid_t      PARTICLE_COMPOUND_TYPE_SEPARATES[8];
 
 herr_t          ierr;
 data_contig_md *BUF_STRUCT;
-mem_monitor *   MEM_MONITOR;
+mem_monitor    *MEM_MONITOR;
 
 void
 print_data(int n)
@@ -71,7 +71,7 @@ append_h5_data(bench_params params, time_step *ts, hid_t loc, hid_t *dset_ids, h
 
     dapl = H5Pcreate(H5P_DATASET_ACCESS);
 
-    int *  data_1D_INT, **data_2D_INT, ***data_3D_INT;
+    int   *data_1D_INT, **data_2D_INT, ***data_3D_INT;
     float *data_1D_FLOAT, **data_2D_FLOAT, ***data_3D_FLOAT;
 
     if (params.num_dims == 1) {
@@ -473,7 +473,7 @@ _run_benchmark_modify(hid_t file_id, hid_t fapl, hid_t gapl, hid_t filespace, be
         *inner_metadata_time += (meta_time1 + meta_time2 + meta_time3 + meta_time4 + meta_time5);
     }
 
-    mem_monitor_final_run(MEM_MONITOR, &metadata_time_imp, &read_time_imp);
+    mem_monitor_final_run(MEM_MONITOR, &metadata_time_imp, &read_time_imp, NULL, NULL);
     *raw_read_time_out += read_time_imp;
     *inner_metadata_time += metadata_time_imp;
     *total_data_size_out = nts * actual_read_cnt * (6 * sizeof(float) + 2 * sizeof(int));
@@ -657,7 +657,7 @@ main(int argc, char *argv[])
 
     if (MY_RANK == 0) {
         human_readable value;
-        char *         mode_str = NULL;
+        char          *mode_str = NULL;
 
         if (has_vol_async) {
             mode_str = "ASYNC";

--- a/h5bench_patterns/h5bench_overwrite.c
+++ b/h5bench_patterns/h5bench_overwrite.c
@@ -32,7 +32,7 @@ hid_t      PARTICLE_COMPOUND_TYPE_SEPARATES[8];
 
 herr_t          ierr;
 data_contig_md *BUF_STRUCT;
-mem_monitor *   MEM_MONITOR;
+mem_monitor    *MEM_MONITOR;
 
 void
 print_data(int n)
@@ -67,7 +67,7 @@ overwrite_h5_data(bench_params params, time_step *ts, hid_t loc, hid_t *dset_ids
 
     dapl = H5Pcreate(H5P_DATASET_ACCESS);
 
-    int *  data_1D_INT, **data_2D_INT, ***data_3D_INT;
+    int   *data_1D_INT, **data_2D_INT, ***data_3D_INT;
     float *data_1D_FLOAT, **data_2D_FLOAT, ***data_3D_FLOAT;
 
     if (params.num_dims == 1) {
@@ -449,7 +449,7 @@ _run_benchmark_modify(hid_t file_id, hid_t fapl, hid_t gapl, hid_t filespace, be
         *inner_metadata_time += (meta_time1 + meta_time2 + meta_time3 + meta_time4 + meta_time5);
     }
 
-    mem_monitor_final_run(MEM_MONITOR, &metadata_time_imp, &read_time_imp);
+    mem_monitor_final_run(MEM_MONITOR, &metadata_time_imp, &read_time_imp, NULL, NULL);
     *raw_read_time_out += read_time_imp;
     *inner_metadata_time += metadata_time_imp;
     *total_data_size_out = nts * actual_read_cnt * (6 * sizeof(float) + 2 * sizeof(int));
@@ -633,7 +633,7 @@ main(int argc, char *argv[])
 
     if (MY_RANK == 0) {
         human_readable value;
-        char *         mode_str = NULL;
+        char          *mode_str = NULL;
 
         if (has_vol_async) {
             mode_str = "ASYNC";

--- a/h5bench_patterns/h5bench_read.c
+++ b/h5bench_patterns/h5bench_read.c
@@ -63,7 +63,7 @@ int        subfiling = 0;
 
 herr_t          ierr;
 data_contig_md *BUF_STRUCT;
-mem_monitor *   MEM_MONITOR;
+mem_monitor    *MEM_MONITOR;
 
 void
 print_data(int n)
@@ -278,10 +278,14 @@ set_dataspace(bench_params params, unsigned long long try_read_elem_cnt, hid_t *
 int
 _run_benchmark_read(hid_t file_id, hid_t fapl, hid_t gapl, hid_t filespace, bench_params params,
                     unsigned long *total_data_size_out, unsigned long *raw_read_time_out,
-                    unsigned long *inner_metadata_time)
+                    unsigned long *inner_metadata_time, unsigned long *data_time_per_step,
+                    unsigned long *metadata_time_per_step, unsigned long *data_wait_time_per_step,
+                    unsigned long *metadata_wait_time_per_step)
 {
-    *raw_read_time_out               = 0;
-    *inner_metadata_time             = 0;
+    *raw_read_time_out   = 0;
+    *inner_metadata_time = 0;
+    memset(metadata_time_per_step, 0, params.cnt_time_step * sizeof(unsigned long));
+    memset(data_time_per_step, 0, params.cnt_time_step * sizeof(unsigned long));
     int                nts           = params.cnt_time_step;
     unsigned long long read_elem_cnt = params.try_num_particles;
     hid_t              grp;
@@ -370,11 +374,14 @@ _run_benchmark_read(hid_t file_id, hid_t fapl, hid_t gapl, hid_t filespace, benc
             }
         }
 
-        *raw_read_time_out += (read_time_exp + read_time_imp);
-        *inner_metadata_time += (meta_time1 + meta_time2 + meta_time3 + meta_time4 + meta_time5);
+        metadata_time_per_step[ts_index] = (meta_time1 + meta_time2 + meta_time3 + meta_time4 + meta_time5);
+        data_time_per_step[ts_index]     = (read_time_exp + read_time_imp);
+        *raw_read_time_out += data_time_per_step[ts_index];
+        *inner_metadata_time += metadata_time_per_step[ts_index];
     }
 
-    mem_monitor_final_run(MEM_MONITOR, &metadata_time_imp, &read_time_imp);
+    mem_monitor_final_run(MEM_MONITOR, &metadata_time_imp, &read_time_imp, data_wait_time_per_step,
+                          metadata_wait_time_per_step);
     *raw_read_time_out += read_time_imp;
     *inner_metadata_time += metadata_time_imp;
     *total_data_size_out = nts * actual_read_cnt * (6 * sizeof(float) + 2 * sizeof(int));
@@ -416,13 +423,12 @@ main(int argc, char *argv[])
     assert(MPI_THREAD_MULTIPLE == mpi_thread_lvl_provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &MY_RANK);
     MPI_Comm_size(MPI_COMM_WORLD, &NUM_RANKS);
-
-    int sleep_time = 0;
-
-    bench_params params;
-
-    char *cfg_file_path = argv[1];
-    char *file_name     = argv[2]; // data file to read
+    int            sleep_time = 0;
+    bench_params   params;
+    char          *cfg_file_path      = argv[1];
+    char          *file_name          = argv[2]; // data file to read
+    unsigned long *data_time_per_step = NULL, *metadata_time_per_step = NULL;
+    unsigned long *data_wait_time_per_step = NULL, *metadata_wait_time_per_step = NULL;
 
     if (MY_RANK == 0) {
         printf("Configuration file: %s\n", argv[1]);
@@ -516,6 +522,11 @@ main(int argc, char *argv[])
         printf("Number of particles available per rank: %llu \n", NUM_PARTICLES);
     }
 
+    data_time_per_step          = malloc(NUM_TIMESTEPS * sizeof(unsigned long));
+    metadata_time_per_step      = malloc(NUM_TIMESTEPS * sizeof(unsigned long));
+    data_wait_time_per_step     = malloc(NUM_TIMESTEPS * sizeof(unsigned long));
+    metadata_wait_time_per_step = malloc(NUM_TIMESTEPS * sizeof(unsigned long));
+
     MPI_Barrier(MPI_COMM_WORLD);
 
     MPI_Allreduce(&NUM_PARTICLES, &TOTAL_PARTICLES, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
@@ -537,7 +548,8 @@ main(int argc, char *argv[])
     unsigned long raw_read_time, metadata_time, local_data_size;
 
     int ret = _run_benchmark_read(file_id, fapl, gapl, filespace, params, &local_data_size, &raw_read_time,
-                                  &metadata_time);
+                                  &metadata_time, data_time_per_step, metadata_time_per_step,
+                                  data_wait_time_per_step, metadata_wait_time_per_step);
 
     if (ret < 0) {
         if (MY_RANK == 0)
@@ -558,7 +570,7 @@ main(int argc, char *argv[])
 
     if (MY_RANK == 0) {
         human_readable value;
-        char *         mode_str = NULL;
+        char          *mode_str = NULL;
 
         if (has_vol_async) {
             mode_str = "ASYNC";
@@ -617,6 +629,29 @@ main(int argc, char *argv[])
             value = format_human_readable(or_bs);
             fprintf(params.csv_fs, "observed rate, %.3f, %cB/s\n", value.value, value.unit);
             fprintf(params.csv_fs, "observed time, %.3f, %s\n", oct_s, "seconds");
+            // Per timestep data time
+            for (int i = 0; i < NUM_TIMESTEPS; i++) {
+                float t = (float)data_time_per_step[i] / (1000.0 * 1000.0);
+                fprintf(params.csv_fs, "timestep %d data time, %.3f, %s\n", i, t, "seconds");
+            }
+            // Per timestep inner metadata time
+            for (int i = 0; i < NUM_TIMESTEPS; i++) {
+                float t = (float)metadata_time_per_step[i] / (1000.0 * 1000.0);
+                fprintf(params.csv_fs, "timestep %d metadata time, %.3f, %s\n", i, t, "seconds");
+            }
+            // Print wait time if async is enabled
+            if (has_vol_async) {
+                // Per timestep data wait time
+                for (int i = 0; i < NUM_TIMESTEPS; i++) {
+                    float t = (float)data_wait_time_per_step[i] / (1000.0 * 1000.0);
+                    fprintf(params.csv_fs, "timestep %d data wait time, %.3f, %s\n", i, t, "seconds");
+                }
+                // Per timestep metadata wait time
+                for (int i = 0; i < NUM_TIMESTEPS; i++) {
+                    float t = (float)metadata_wait_time_per_step[i] / (1000.0 * 1000.0);
+                    fprintf(params.csv_fs, "timestep %d metadata wait time, %.3f, %s\n", i, t, "seconds");
+                }
+            }
             fclose(params.csv_fs);
         }
     }
@@ -631,6 +666,16 @@ error:
 
 done:
     H5close();
+
+    if (data_time_per_step)
+        free(data_time_per_step);
+    if (metadata_time_per_step)
+        free(metadata_time_per_step);
+    if (data_wait_time_per_step)
+        free(data_wait_time_per_step);
+    if (metadata_wait_time_per_step)
+        free(metadata_wait_time_per_step);
+
     MPI_Finalize();
     return 0;
 }

--- a/h5bench_patterns/h5bench_write.c
+++ b/h5bench_patterns/h5bench_write.c
@@ -615,7 +615,7 @@ data_write_interleaved_to_interleaved(time_step *ts, hid_t loc, hid_t *dset_ids,
 
     unsigned t2 = get_time_usec();
     ierr        = H5Dwrite_async(dset_ids[0], PARTICLE_COMPOUND_TYPE, memspace, filespace, plist_id, data_in,
-                          ts->es_data);
+                                 ts->es_data);
 
     // should write all things in data_in
     unsigned t3    = get_time_usec();
@@ -704,7 +704,7 @@ _prepare_data(bench_params params, hid_t *filespace_out, hid_t *memspace_out,
             set_select_space_multi_3D_array(filespace_out, memspace_out, params.dim_1, params.dim_2,
                                             params.dim_3);
             data     = (void *)prepare_data_contig_3D(particle_cnt, params.dim_1, params.dim_2, params.dim_3,
-                                                  data_size);
+                                                      data_size);
             dset_cnt = 8;
             break;
         default:
@@ -718,7 +718,9 @@ _prepare_data(bench_params params, hid_t *filespace_out, hid_t *memspace_out,
 int
 _run_benchmark_write(bench_params params, hid_t file_id, hid_t fapl, hid_t filespace, hid_t memspace,
                      void *data, unsigned long data_size, unsigned long *total_data_size_out,
-                     unsigned long *data_time_total, unsigned long *metadata_time_total)
+                     unsigned long *data_time_total, unsigned long *metadata_time_total,
+                     unsigned long *data_time_per_step, unsigned long *metadata_time_per_step,
+                     unsigned long *data_wait_time_per_step, unsigned long *metadata_wait_time_per_step)
 {
     unsigned long long data_preparation_time;
 
@@ -726,6 +728,8 @@ _run_benchmark_write(bench_params params, hid_t file_id, hid_t fapl, hid_t files
     int           timestep_cnt = params.cnt_time_step;
     *metadata_time_total       = 0;
     *data_time_total           = 0;
+    memset(metadata_time_per_step, 0, timestep_cnt * sizeof(unsigned long));
+    memset(data_time_per_step, 0, timestep_cnt * sizeof(unsigned long));
     char  grp_name[128];
     int   grp_cnt = 0, dset_cnt = 0;
     hid_t plist_id; //, filespace, memspace;
@@ -760,7 +764,7 @@ _run_benchmark_write(bench_params params, hid_t file_id, hid_t fapl, hid_t files
         meta_time1 = 0, meta_time2 = 0, meta_time3 = 0, meta_time4 = 0, meta_time5 = 0;
         time_step *ts = &(MEM_MONITOR->time_steps[ts_index]);
         MEM_MONITOR->mem_used += ts->mem_size;
-        //        print_mem_bound(MEM_MONITOR);
+
         sprintf(grp_name, "Timestep_%d", ts_index);
         assert(ts);
 
@@ -842,14 +846,16 @@ _run_benchmark_write(bench_params params, hid_t file_id, hid_t fapl, hid_t files
             }
         }
 
-        *metadata_time_total += (meta_time1 + meta_time2 + meta_time3 + meta_time4);
-        *data_time_total += (data_time_exp + data_time_imp);
+        metadata_time_per_step[ts_index] = meta_time1 + meta_time2 + meta_time3 + meta_time4;
+        data_time_per_step[ts_index]     = data_time_exp + data_time_imp;
+        *metadata_time_total += metadata_time_per_step[ts_index];
+        *data_time_total += data_time_per_step[ts_index];
     } // end for timestep_cnt
 
     // all done, check if any timesteps undone
 
-    mem_monitor_final_run(MEM_MONITOR, &metadata_time_imp, &data_time_imp);
-
+    mem_monitor_final_run(MEM_MONITOR, &metadata_time_imp, &data_time_imp, data_wait_time_per_step,
+                          metadata_wait_time_per_step);
     *metadata_time_total += metadata_time_imp;
     *data_time_total += data_time_imp;
 
@@ -979,10 +985,12 @@ main(int argc, char *argv[])
     assert(MPI_THREAD_MULTIPLE == mpi_thread_lvl_provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &MY_RANK);
     MPI_Comm_size(MPI_COMM_WORLD, &NUM_RANKS);
-    MPI_Comm           comm    = MPI_COMM_WORLD;
-    MPI_Info           info    = MPI_INFO_NULL;
-    char *             num_str = "1024 Ks";
-    unsigned long long num     = 0;
+    MPI_Comm           comm               = MPI_COMM_WORLD;
+    MPI_Info           info               = MPI_INFO_NULL;
+    char              *num_str            = "1024 Ks";
+    unsigned long long num                = 0;
+    unsigned long     *data_time_per_step = NULL, *metadata_time_per_step = NULL;
+    unsigned long     *data_wait_time_per_step = NULL, *metadata_wait_time_per_step = NULL;
 
     char buffer[200];
 
@@ -996,7 +1004,7 @@ main(int argc, char *argv[])
         }
     }
 
-    char *       output_file;
+    char        *output_file;
     bench_params params;
 
     char *cfg_file_path = argv[1];
@@ -1051,6 +1059,11 @@ main(int argc, char *argv[])
     unsigned long data_size             = 0;
     unsigned long data_preparation_time = 0;
 
+    data_time_per_step          = malloc(NUM_TIMESTEPS * sizeof(unsigned long));
+    metadata_time_per_step      = malloc(NUM_TIMESTEPS * sizeof(unsigned long));
+    data_wait_time_per_step     = malloc(NUM_TIMESTEPS * sizeof(unsigned long));
+    metadata_wait_time_per_step = malloc(NUM_TIMESTEPS * sizeof(unsigned long));
+
     MPI_Barrier(MPI_COMM_WORLD);
 
     MPI_Allreduce(&NUM_PARTICLES, &TOTAL_PARTICLES, 1, MPI_LONG_LONG, MPI_SUM, comm);
@@ -1066,9 +1079,7 @@ main(int argc, char *argv[])
     ALIGN_THRESHOLD = params.align_threshold;
     ALIGN_LEN       = params.align_len;
 
-    if (params.file_per_proc) {
-    }
-    else {
+    if (!params.file_per_proc) {
 #ifdef HAVE_SUBFILING
         if (params.subfiling == 1)
             H5Pset_fapl_subfiling(fapl, NULL);
@@ -1098,14 +1109,16 @@ main(int argc, char *argv[])
     unsigned long tfopen_end = get_time_usec();
 
     if (MY_RANK == 0)
-        printf("Opened HDF5 file... \n");
+        printf("Opened HDF5 file...\n");
 
     MPI_Barrier(MPI_COMM_WORLD);
     unsigned long t2 = get_time_usec(); // t2 - t1: metadata: creating/opening
 
     unsigned long raw_write_time, inner_metadata_time, local_data_size;
-    int           stat = _run_benchmark_write(params, file_id, fapl, filespace, memspace, data, data_size,
-                                    &local_data_size, &raw_write_time, &inner_metadata_time);
+    int           stat =
+        _run_benchmark_write(params, file_id, fapl, filespace, memspace, data, data_size, &local_data_size,
+                             &raw_write_time, &inner_metadata_time, data_time_per_step,
+                             metadata_time_per_step, data_wait_time_per_step, metadata_wait_time_per_step);
 
     if (stat < 0) {
         if (MY_RANK == 0)
@@ -1131,7 +1144,7 @@ main(int argc, char *argv[])
 
     if (MY_RANK == 0) {
         human_readable value;
-        char *         mode_str = NULL;
+        char          *mode_str = NULL;
 
         if (has_vol_async) {
             mode_str = "ASYNC";
@@ -1197,9 +1210,41 @@ main(int argc, char *argv[])
             value = format_human_readable(or_bs);
             fprintf(params.csv_fs, "observed rate, %.3f, %cB/s\n", value.value, value.unit);
             fprintf(params.csv_fs, "observed time, %.3f, %s\n", oct_s, "seconds");
+            // Per timestep data time
+            for (int i = 0; i < NUM_TIMESTEPS; i++) {
+                float t = (float)data_time_per_step[i] / (1000.0 * 1000.0);
+                fprintf(params.csv_fs, "timestep %d data time, %.3f, %s\n", i, t, "seconds");
+            }
+            // Per timestep inner metadata time
+            for (int i = 0; i < NUM_TIMESTEPS; i++) {
+                float t = (float)metadata_time_per_step[i] / (1000.0 * 1000.0);
+                fprintf(params.csv_fs, "timestep %d metadata time, %.3f, %s\n", i, t, "seconds");
+            }
+            // Print wait time if async is enabled
+            if (has_vol_async) {
+                // Per timestep data wait time
+                for (int i = 0; i < NUM_TIMESTEPS; i++) {
+                    float t = (float)data_wait_time_per_step[i] / (1000.0 * 1000.0);
+                    fprintf(params.csv_fs, "timestep %d data wait time, %.3f, %s\n", i, t, "seconds");
+                }
+                // Per timestep metadata wait time
+                for (int i = 0; i < NUM_TIMESTEPS; i++) {
+                    float t = (float)metadata_wait_time_per_step[i] / (1000.0 * 1000.0);
+                    fprintf(params.csv_fs, "timestep %d metadata wait time, %.3f, %s\n", i, t, "seconds");
+                }
+            }
             fclose(params.csv_fs);
         }
     }
+
+    if (data_time_per_step)
+        free(data_time_per_step);
+    if (metadata_time_per_step)
+        free(metadata_time_per_step);
+    if (data_wait_time_per_step)
+        free(data_wait_time_per_step);
+    if (metadata_wait_time_per_step)
+        free(metadata_wait_time_per_step);
 
     MPI_Finalize();
     return 0;

--- a/h5bench_patterns/h5bench_write_normal_dist.c
+++ b/h5bench_patterns/h5bench_write_normal_dist.c
@@ -653,7 +653,7 @@ data_write_interleaved_to_interleaved(time_step *ts, hid_t loc, hid_t *dset_ids,
 
     unsigned t2 = get_time_usec();
     ierr        = H5Dwrite_async(dset_ids[0], PARTICLE_COMPOUND_TYPE, memspace, filespace, plist_id, data_in,
-                          ts->es_data);
+                                 ts->es_data);
 
     // should write all things in data_in
     unsigned t3    = get_time_usec();
@@ -742,7 +742,7 @@ _prepare_data(bench_params params, hid_t *filespace_out, hid_t *memspace_out,
             set_select_space_multi_3D_array(filespace_out, memspace_out, params.dim_1, params.dim_2,
                                             params.dim_3);
             data     = (void *)prepare_data_contig_3D(particle_cnt, params.dim_1, params.dim_2, params.dim_3,
-                                                  data_size);
+                                                      data_size);
             dset_cnt = 8;
             break;
         default:
@@ -886,7 +886,7 @@ _run_benchmark_write(bench_params params, hid_t file_id, hid_t fapl, hid_t files
 
     // all done, check if any timesteps undone
 
-    mem_monitor_final_run(MEM_MONITOR, &metadata_time_imp, &data_time_imp);
+    mem_monitor_final_run(MEM_MONITOR, &metadata_time_imp, &data_time_imp, NULL, NULL);
 
     *metadata_time_total += metadata_time_imp;
     *data_time_total += data_time_imp;
@@ -1019,7 +1019,7 @@ main(int argc, char *argv[])
     MPI_Comm_size(MPI_COMM_WORLD, &NUM_RANKS);
     MPI_Comm           comm    = MPI_COMM_WORLD;
     MPI_Info           info    = MPI_INFO_NULL;
-    char *             num_str = "1024 Ks";
+    char              *num_str = "1024 Ks";
     unsigned long long num     = 0;
 
     char buffer[200];
@@ -1034,7 +1034,7 @@ main(int argc, char *argv[])
         }
     }
 
-    char *       output_file;
+    char        *output_file;
     bench_params params;
 
     char *cfg_file_path = argv[1];
@@ -1157,7 +1157,7 @@ main(int argc, char *argv[])
 
     unsigned long raw_write_time, inner_metadata_time, local_data_size;
     int           stat = _run_benchmark_write(params, file_id, fapl, filespace, memspace, data, data_size,
-                                    &local_data_size, &raw_write_time, &inner_metadata_time);
+                                              &local_data_size, &raw_write_time, &inner_metadata_time);
 
     if (stat < 0) {
         if (MY_RANK == 0)
@@ -1188,7 +1188,7 @@ main(int argc, char *argv[])
 
     if (MY_RANK == 0) {
         human_readable value;
-        char *         mode_str = NULL;
+        char          *mode_str = NULL;
 
         if (has_vol_async) {
             mode_str = "ASYNC";

--- a/h5bench_patterns/h5bench_write_unlimited.c
+++ b/h5bench_patterns/h5bench_write_unlimited.c
@@ -467,15 +467,15 @@ data_write_contig_contig_MD_array(time_step *ts, hid_t loc, hid_t *dset_ids, hid
     ierr =
         H5Dwrite_async(dset_ids[2], H5T_NATIVE_FLOAT, memspace, filespace, plist_id, data_in->z, ts->es_data);
     ierr        = H5Dwrite_async(dset_ids[3], H5T_NATIVE_FLOAT, memspace, filespace, plist_id, data_in->px,
-                          ts->es_data);
+                                 ts->es_data);
     ierr        = H5Dwrite_async(dset_ids[4], H5T_NATIVE_FLOAT, memspace, filespace, plist_id, data_in->py,
-                          ts->es_data);
+                                 ts->es_data);
     ierr        = H5Dwrite_async(dset_ids[5], H5T_NATIVE_FLOAT, memspace, filespace, plist_id, data_in->pz,
-                          ts->es_data);
+                                 ts->es_data);
     ierr        = H5Dwrite_async(dset_ids[6], H5T_NATIVE_INT, memspace, filespace, plist_id, data_in->id_1,
-                          ts->es_data);
+                                 ts->es_data);
     ierr        = H5Dwrite_async(dset_ids[7], H5T_NATIVE_FLOAT, memspace, filespace, plist_id, data_in->id_2,
-                          ts->es_data);
+                                 ts->es_data);
     unsigned t3 = get_time_usec();
 
     *metadata_time = t2 - t1;
@@ -551,21 +551,21 @@ data_write_interleaved_to_contig(time_step *ts, hid_t loc, hid_t *dset_ids, hid_
                                   dcpl, H5P_DEFAULT, ts->es_meta_create);
     unsigned t2 = get_time_usec();
     ierr        = H5Dwrite_async(dset_ids[0], PARTICLE_COMPOUND_TYPE, memspace, filespace, plist_id, data_in,
-                          ts->es_data);
+                                 ts->es_data);
     ierr        = H5Dwrite_async(dset_ids[1], PARTICLE_COMPOUND_TYPE, memspace, filespace, plist_id, data_in,
-                          ts->es_data);
+                                 ts->es_data);
     ierr        = H5Dwrite_async(dset_ids[2], PARTICLE_COMPOUND_TYPE, memspace, filespace, plist_id, data_in,
-                          ts->es_data);
+                                 ts->es_data);
     ierr        = H5Dwrite_async(dset_ids[3], PARTICLE_COMPOUND_TYPE, memspace, filespace, plist_id, data_in,
-                          ts->es_data);
+                                 ts->es_data);
     ierr        = H5Dwrite_async(dset_ids[4], PARTICLE_COMPOUND_TYPE, memspace, filespace, plist_id, data_in,
-                          ts->es_data);
+                                 ts->es_data);
     ierr        = H5Dwrite_async(dset_ids[5], PARTICLE_COMPOUND_TYPE, memspace, filespace, plist_id, data_in,
-                          ts->es_data);
+                                 ts->es_data);
     ierr        = H5Dwrite_async(dset_ids[6], PARTICLE_COMPOUND_TYPE, memspace, filespace, plist_id, data_in,
-                          ts->es_data);
+                                 ts->es_data);
     ierr        = H5Dwrite_async(dset_ids[7], PARTICLE_COMPOUND_TYPE, memspace, filespace, plist_id, data_in,
-                          ts->es_data);
+                                 ts->es_data);
     unsigned t3 = get_time_usec();
     *metadata_time = t2 - t1;
     *data_time     = t3 - t2;
@@ -589,7 +589,7 @@ data_write_interleaved_to_interleaved(time_step *ts, hid_t loc, hid_t *dset_ids,
                                   H5P_DEFAULT, ts->es_meta_create);
     unsigned t2 = get_time_usec();
     ierr        = H5Dwrite_async(dset_ids[0], PARTICLE_COMPOUND_TYPE, memspace, filespace, plist_id, data_in,
-                          ts->es_data);
+                                 ts->es_data);
     // should write all things in data_in
     unsigned t3    = get_time_usec();
     *metadata_time = t2 - t1;
@@ -677,7 +677,7 @@ _prepare_data(bench_params params, hid_t *filespace_out, hid_t *memspace_out,
             set_select_space_multi_3D_array(params, filespace_out, memspace_out, params.dim_1, params.dim_2,
                                             params.dim_3);
             data     = (void *)prepare_data_contig_3D(particle_cnt, params.dim_1, params.dim_2, params.dim_3,
-                                                  data_size);
+                                                      data_size);
             dset_cnt = 8;
             break;
         default:
@@ -818,7 +818,7 @@ _run_benchmark_write(bench_params params, hid_t file_id, hid_t fapl, hid_t files
 
     // all done, check if any timesteps undone
 
-    mem_monitor_final_run(MEM_MONITOR, &metadata_time_imp, &data_time_imp);
+    mem_monitor_final_run(MEM_MONITOR, &metadata_time_imp, &data_time_imp, NULL, NULL);
 
     *metadata_time_total += metadata_time_imp;
     *data_time_total += data_time_imp;
@@ -948,7 +948,7 @@ main(int argc, char *argv[])
     MPI_Comm_size(MPI_COMM_WORLD, &NUM_RANKS);
     MPI_Comm           comm    = MPI_COMM_WORLD;
     MPI_Info           info    = MPI_INFO_NULL;
-    char *             num_str = "1024 Ks";
+    char              *num_str = "1024 Ks";
     unsigned long long num     = 0;
 
     int rand_seed_value = time(NULL);
@@ -961,7 +961,7 @@ main(int argc, char *argv[])
         }
     }
 
-    char *       output_file;
+    char        *output_file;
     bench_params params;
 
     char *cfg_file_path = argv[1];
@@ -1055,7 +1055,7 @@ main(int argc, char *argv[])
 
     unsigned long raw_write_time, inner_metadata_time, local_data_size;
     int           stat = _run_benchmark_write(params, file_id, fapl, filespace, memspace, data, data_size,
-                                    &local_data_size, &raw_write_time, &inner_metadata_time);
+                                              &local_data_size, &raw_write_time, &inner_metadata_time);
 
     if (stat < 0) {
         if (MY_RANK == 0)
@@ -1078,7 +1078,7 @@ main(int argc, char *argv[])
 
     if (MY_RANK == 0) {
         human_readable value;
-        char *         mode_str = NULL;
+        char          *mode_str = NULL;
 
         if (has_vol_async) {
             mode_str = "ASYNC";


### PR DESCRIPTION
Adds per step times in CSV for h5bench write/read. If async is enabled the wait times per step are also written to CSV. The following results are from Perlmutter single node 32 ranks.


Config/output when async is enabled:

```
{
    "mpi": {
        "command": "srun",
        "ranks": "32",
        "configuration": "-N 1 -n 32"
    },
    "vol": {
        "library": "/pscratch/sd/n/nlewi26/src/vol_connectors/lib:/pscratch/sd/n/nlewi26/src/vol-async/install/lib:/pscratch/sd/n/nlewi26/src/argobots-1.2/install/lib:/pscratch/sd/n/nlewi26/src/hdf5/install/lib:/pscratch/sd/n/nlewi26/src/vol-cache/install/lib:",
        "path": "/pscratch/sd/n/nlewi26/src/vol_connectors/lib",
        "connector": "async under_vol=0;under_info={}"
    },
    "file-system": {
        "lustre": {
            "stripe-size": "1M",
            "stripe-count": "1"
        }
    },
    "directory": "/pscratch/sd/n/nlewi26/h5bench_data",
    "benchmarks": [
        {
            "benchmark": "write",
            "file": "test.h5",
            "configuration": {
                "MEM_PATTERN": "CONTIG",
                "FILE_PATTERN": "CONTIG",
                "TIMESTEPS": "5",
                "DELAYED_CLOSE_TIMESTEPS": "1",
                "COLLECTIVE_DATA": "YES",
                "COLLECTIVE_METADATA": "YES",
                "EMULATED_COMPUTE_TIME_PER_TIMESTEP": "20 s", 
                "NUM_DIMS": "1",
                "DIM_1": "8388608",
                "DIM_2": "1",
                "DIM_3": "1",
                "CSV_FILE": "write_output.csv",
                "MODE": "ASYNC"
            }
        },
        {
            "benchmark": "read",
            "file": "test.h5",
            "configuration": {
                "MEM_PATTERN": "CONTIG",
                "FILE_PATTERN": "CONTIG",
                "TIMESTEPS": "5",
                "DELAYED_CLOSE_TIMESTEPS": "1",
                "COLLECTIVE_DATA": "YES",
                "COLLECTIVE_METADATA": "YES",
                "EMULATED_COMPUTE_TIME_PER_TIMESTEP": "20 s", 
                "NUM_DIMS": "1",
                "DIM_1": "8388608",
                "DIM_2": "1",
                "DIM_3": "1",
                "CSV_FILE": "read_output.csv",
                "MODE": "ASYNC"
            }
        }
    ]
}
```

Write benchmark:
```
metric, value, unit
operation, write, 
ranks, 32, 
collective data, YES, 
collective meta, YES, 
subfiling, NO, 
total compute time, 80.000, seconds
total size, 40.000, GB
raw time, 0.002, seconds
raw rate, 25.852, TB/s
metadata time, 27.027, seconds
observed rate, 1.464, GB/s
observed time, 107.315, seconds
timestep 0 data time, 0.001, seconds
timestep 1 data time, 0.000, seconds
timestep 2 data time, 0.000, seconds
timestep 3 data time, 0.000, seconds
timestep 4 data time, 0.000, seconds
timestep 0 metadata time, 0.006, seconds
timestep 1 metadata time, 14.011, seconds
timestep 2 metadata time, 0.002, seconds
timestep 3 metadata time, 0.002, seconds
timestep 4 metadata time, 0.002, seconds
timestep 0 data wait time, 0.000, seconds
timestep 1 data wait time, 0.000, seconds
timestep 2 data wait time, 0.000, seconds
timestep 3 data wait time, 0.000, seconds
timestep 4 data wait time, 0.000, seconds
timestep 0 metadata wait time, 0.000, seconds
timestep 1 metadata wait time, 0.000, seconds
timestep 2 metadata wait time, 0.000, seconds
timestep 3 metadata wait time, 0.000, seconds
timestep 4 metadata wait time, 13.004, seconds
```

Read benchmark:
```
metric, value, unit
operation, read, 
ranks, 32, 
collective data, YES, 
collective meta, YES, 
subfiling, NO, 
total compute time, 80.000, seconds
total size, 40.000, GB
raw time, 0.001, seconds
raw rate, 33.443, TB/s
metadata time, 14.044, seconds
observed rate, 2.838, GB/s
observed time, 94.094, seconds
timestep 0 data time, 0.000, seconds
timestep 1 data time, 0.000, seconds
timestep 2 data time, 0.000, seconds
timestep 3 data time, 0.000, seconds
timestep 4 data time, 0.000, seconds
timestep 0 metadata time, 0.001, seconds
timestep 1 metadata time, 7.036, seconds
timestep 2 metadata time, 0.002, seconds
timestep 3 metadata time, 0.002, seconds
timestep 4 metadata time, 0.002, seconds
timestep 0 data wait time, 0.000, seconds
timestep 1 data wait time, 0.000, seconds
timestep 2 data wait time, 0.000, seconds
timestep 3 data wait time, 0.000, seconds
timestep 4 data wait time, 0.000, seconds
timestep 0 metadata wait time, 0.000, seconds
timestep 1 metadata wait time, 0.000, seconds
timestep 2 metadata wait time, 0.000, seconds
timestep 3 metadata wait time, 0.000, seconds
timestep 4 metadata wait time, 7.003, seconds
```

output when sync is enabled.

```
{
    "mpi": {
        "command": "srun",
        "ranks": "32",
        "configuration": "-N 1 -n 32"
    },
    "vol": {
        "library": "/pscratch/sd/n/nlewi26/src/vol_connectors/lib:/pscratch/sd/n/nlewi26/src/vol-async/install/lib:/pscratch/sd/n/nlewi26/src/argobots-1.2/install/lib:/pscratch/sd/n/nlewi26/src/hdf5/install/lib:/pscratch/sd/n/nlewi26/src/vol-cache/install/lib:",
        "path": "/pscratch/sd/n/nlewi26/src/vol_connectors/lib",
        "connector": ""
    },
    "file-system": {
        "lustre": {
            "stripe-size": "1M",
            "stripe-count": "1"
        }
    },
    "directory": "/pscratch/sd/n/nlewi26/h5bench_data",
    "benchmarks": [
        {
            "benchmark": "write",
            "file": "test.h5",
            "configuration": {
                "MEM_PATTERN": "CONTIG",
                "FILE_PATTERN": "CONTIG",
                "TIMESTEPS": "5",
                "DELAYED_CLOSE_TIMESTEPS": "1",
                "COLLECTIVE_DATA": "YES",
                "COLLECTIVE_METADATA": "YES",
                "EMULATED_COMPUTE_TIME_PER_TIMESTEP": "20 s", 
                "NUM_DIMS": "1",
                "DIM_1": "8388608",
                "DIM_2": "1",
                "DIM_3": "1",
                "CSV_FILE": "write_output.csv",
                "MODE": "SYNC"
            }
        },
        {
            "benchmark": "read",
            "file": "test.h5",
            "configuration": {
                "MEM_PATTERN": "CONTIG",
                "FILE_PATTERN": "CONTIG",
                "TIMESTEPS": "5",
                "DELAYED_CLOSE_TIMESTEPS": "1",
                "COLLECTIVE_DATA": "YES",
                "COLLECTIVE_METADATA": "YES",
                "EMULATED_COMPUTE_TIME_PER_TIMESTEP": "20 s", 
                "NUM_DIMS": "1",
                "DIM_1": "8388608",
                "DIM_2": "1",
                "DIM_3": "1",
                "CSV_FILE": "read_output.csv",
                "MODE": "SYNC"
            }
        }
    ]
}
```

Write benchmark:
```
metric, value, unit
operation, write, 
ranks, 32, 
collective data, YES, 
collective meta, YES, 
subfiling, NO, 
total compute time, 80.000, seconds
total size, 40.000, GB
raw time, 60.167, seconds
raw rate, 680.775, MB/s
metadata time, 0.022, seconds
observed rate, 679.188, MB/s
observed time, 140.307, seconds
timestep 0 data time, 12.248, seconds
timestep 1 data time, 12.020, seconds
timestep 2 data time, 11.987, seconds
timestep 3 data time, 12.006, seconds
timestep 4 data time, 11.907, seconds
timestep 0 metadata time, 0.017, seconds
timestep 1 metadata time, 0.002, seconds
timestep 2 metadata time, 0.002, seconds
timestep 3 metadata time, 0.001, seconds
timestep 4 metadata time, 0.001, seconds
```

Read benchmark:
```
metric, value, unit
operation, read, 
ranks, 32, 
collective data, YES, 
collective meta, YES, 
subfiling, NO, 
total compute time, 80.000, seconds
total size, 40.000, GB
raw time, 27.535, seconds
raw rate, 1.452, GB/s
metadata time, 0.049, seconds
observed rate, 1.449, GB/s
observed time, 107.589, seconds
timestep 0 data time, 6.290, seconds
timestep 1 data time, 5.490, seconds
timestep 2 data time, 5.459, seconds
timestep 3 data time, 5.086, seconds
timestep 4 data time, 5.210, seconds
timestep 0 metadata time, 0.038, seconds
timestep 1 metadata time, 0.002, seconds
timestep 2 metadata time, 0.003, seconds
timestep 3 metadata time, 0.003, seconds
timestep 4 metadata time, 0.002, seconds
```