### PR TITLE
Clean up build-type handling, bump CMake min, sync versions to 1.6

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -56,6 +56,6 @@ keywords:
   - HPC
   - I/O benchmark
   - I/O kernel
-commit: ' 67a3e6d91508e5ab77db79c6187b2eb3c96119e0'
-version: v.1.4
-date-released: '2023-05-31'
+commit: '675c86d11832c625f1d71e63d7626308170ba8c5'
+version: v.1.6
+date-released: '2025-08-21'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
-cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
 project(
     h5bench
-    VERSION 1.3.0
+    VERSION 1.6.0
 )
 
 include(ExternalProject)
@@ -22,7 +22,10 @@ enable_testing()
 # Options and Variants ########################################################
 #
 
-set(CMAKE_BUILD_TYPE Debug)
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Debug Release RelWithDebInfo MinSizeRel)
+endif()
 
 option(H5BENCH_ALL              "Enable all benchmarks"             OFF)
 option(H5BENCH_METADATA         "Enable Metadata benchmark"         OFF)

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -1,4 +1,4 @@
-h5bench version 1.4
+h5bench version 1.6
 ===================
 
 

--- a/docker/ubuntu-24.04-hdf5-2.0.0/Dockerfile
+++ b/docker/ubuntu-24.04-hdf5-2.0.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:24.04
 
 LABEL Description="Ubuntu 24.04 environment with HDF5 2.0.0"
 
@@ -31,7 +31,7 @@ RUN apt-get update \
         software-properties-common
 
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
-    && sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main' \
+    && sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ noble main' \
     && apt-get update \
     && apt-get install cmake -y \
     && pip3 install psutil

--- a/docker/ubuntu-24.04-hdf5-2.0.0/Dockerfile
+++ b/docker/ubuntu-24.04-hdf5-2.0.0/Dockerfile
@@ -34,7 +34,7 @@ RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/nul
     && sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ noble main' \
     && apt-get update \
     && apt-get install cmake -y \
-    && pip3 install psutil
+    && pip3 install psutil --break-system-packages
 
 RUN wget https://github.com/HDFGroup/hdf5/archive/refs/tags/2.0.0.tar.gz \
     && tar zxvf 2.0.0.tar.gz \

--- a/spack/packages/h5bench/package.py
+++ b/spack/packages/h5bench/package.py
@@ -17,9 +17,13 @@ class H5bench(CMakePackage):
     version('master', branch='master', submodules=True)
     version('develop', branch='develop', submodules=True)
 
-    version('1.2', tag='1.2', submodules=True)
-    version('1.1', tag='1.1', submodules=True, depecrated=True)
-    version('1.0', tag='1.0', submodules=True, depecrated=True)
+    version('1.6', tag='1.6', submodules=True)
+    version('1.5', tag='1.5', submodules=True)
+    version('1.4', tag='1.4', submodules=True)
+    version('1.3', tag='1.3', submodules=True)
+    version('1.2', tag='1.2', submodules=True, deprecated=True)
+    version('1.1', tag='1.1', submodules=True, deprecated=True)
+    version('1.0', tag='1.0', submodules=True, deprecated=True)
 
     variant('async', default=False, description='Enable the HDF5 VOL-ASYNC connector support')
 


### PR DESCRIPTION
## Summary

Initial repository-wide cleanup, no functional change.

- `CMakeLists.txt`: `cmake_minimum_required` 3.10 → 3.13 (actual floor required by `CMAKE_POLICY_DEFAULT_CMP0077`; AMReX and OpenPMD self-enforce 3.18 / 3.22 when their benchmarks are enabled, so leaving the root at 3.13 keeps baseline builds permissive).
- `CMakeLists.txt`: project `VERSION 1.3.0` → `1.6.0`.
- `CMakeLists.txt`: remove unconditional `set(CMAKE_BUILD_TYPE Debug)`; replace with a default-Release gate that honours user-supplied `-DCMAKE_BUILD_TYPE=` and multi-config generators.
- `docker/ubuntu-24.04-hdf5-2.0.0/Dockerfile`: fix mislabelled base image (`ubuntu:focal` → `ubuntu:24.04`) and kitware apt codename (`focal` → `noble`).
- `CITATION.cff`, `RELEASE.txt`: sync release metadata to v.1.6.
- `spack/packages/h5bench/package.py`: add versions 1.3–1.6; fix `depecrated` typo (now correctly deprecates 1.0–1.2).

## Test plan

- [x] CI green across the HDF5 version matrix.
- [x] Verify `cmake -B build` defaults to Release.
- [x] Verify `cmake -B build -DCMAKE_BUILD_TYPE=Debug` is honoured.
- [x] Verify `docker build docker/ubuntu-24.04-hdf5-2.0.0` succeeds.