### PR TITLE
Add fail-fast checks for malloc and HDF5 calls in write/read paths

### DIFF
--- a/commons/h5bench_util.c
+++ b/commons/h5bench_util.c
@@ -14,6 +14,7 @@
 #include <fcntl.h>
 #include <assert.h>
 #include <sys/time.h>
+#include <mpi.h>
 #include <hdf5.h>
 
 #ifdef USE_ASYNC_VOL
@@ -24,6 +25,23 @@
 #endif
 
 #include "h5bench_util.h"
+
+void
+h5bench_die(const char *msg)
+{
+    if (msg)
+        fprintf(stderr, "h5bench: %s\n", msg);
+    fflush(stderr);
+
+    int mpi_initialized = 0;
+    int mpi_finalized   = 0;
+    MPI_Initialized(&mpi_initialized);
+    MPI_Finalized(&mpi_finalized);
+    if (mpi_initialized && !mpi_finalized) {
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+    abort();
+}
 
 int str_to_ull(char *str_in, unsigned long long *num_out);
 int parse_time(char *str_in, duration *time);
@@ -371,40 +389,42 @@ uniform_random_number()
 data_contig_md *
 prepare_contig_memory(long particle_cnt, long dim_1, long dim_2, long dim_3)
 {
-    data_contig_md *buf_struct = (data_contig_md *)malloc(sizeof(data_contig_md));
-    buf_struct->particle_cnt   = particle_cnt;
-    buf_struct->dim_1          = dim_1;
-    buf_struct->dim_2          = dim_2;
-    buf_struct->dim_3          = dim_3;
-    buf_struct->x              = (float *)malloc(particle_cnt * sizeof(float));
-    buf_struct->y              = (float *)malloc(particle_cnt * sizeof(float));
-    buf_struct->z              = (float *)malloc(particle_cnt * sizeof(float));
-    buf_struct->px             = (float *)malloc(particle_cnt * sizeof(float));
-    buf_struct->py             = (float *)malloc(particle_cnt * sizeof(float));
-    buf_struct->pz             = (float *)malloc(particle_cnt * sizeof(float));
-    buf_struct->id_1           = (int *)malloc(particle_cnt * sizeof(int));
-    buf_struct->id_2           = (float *)malloc(particle_cnt * sizeof(float));
+    data_contig_md *buf_struct;
+    H5B_MALLOC(buf_struct, sizeof(data_contig_md));
+    buf_struct->particle_cnt = particle_cnt;
+    buf_struct->dim_1        = dim_1;
+    buf_struct->dim_2        = dim_2;
+    buf_struct->dim_3        = dim_3;
+    H5B_MALLOC(buf_struct->x, particle_cnt * sizeof(float));
+    H5B_MALLOC(buf_struct->y, particle_cnt * sizeof(float));
+    H5B_MALLOC(buf_struct->z, particle_cnt * sizeof(float));
+    H5B_MALLOC(buf_struct->px, particle_cnt * sizeof(float));
+    H5B_MALLOC(buf_struct->py, particle_cnt * sizeof(float));
+    H5B_MALLOC(buf_struct->pz, particle_cnt * sizeof(float));
+    H5B_MALLOC(buf_struct->id_1, particle_cnt * sizeof(int));
+    H5B_MALLOC(buf_struct->id_2, particle_cnt * sizeof(float));
     return buf_struct;
 }
 
 data_contig_md *
 prepare_contig_memory_multi_dim(unsigned long long dim_1, unsigned long long dim_2, unsigned long long dim_3)
 {
-    data_contig_md *buf_struct       = (data_contig_md *)malloc(sizeof(data_contig_md));
+    data_contig_md *buf_struct;
+    H5B_MALLOC(buf_struct, sizeof(data_contig_md));
     buf_struct->dim_1                = dim_1;
     buf_struct->dim_2                = dim_2;
     buf_struct->dim_3                = dim_3;
     unsigned long long num_particles = dim_1 * dim_2 * dim_3;
 
     buf_struct->particle_cnt = num_particles;
-    buf_struct->x            = (float *)malloc(num_particles * sizeof(float));
-    buf_struct->y            = (float *)malloc(num_particles * sizeof(float));
-    buf_struct->z            = (float *)malloc(num_particles * sizeof(float));
-    buf_struct->px           = (float *)malloc(num_particles * sizeof(float));
-    buf_struct->py           = (float *)malloc(num_particles * sizeof(float));
-    buf_struct->pz           = (float *)malloc(num_particles * sizeof(float));
-    buf_struct->id_1         = (int *)malloc(num_particles * sizeof(int));
-    buf_struct->id_2         = (float *)malloc(num_particles * sizeof(float));
+    H5B_MALLOC(buf_struct->x, num_particles * sizeof(float));
+    H5B_MALLOC(buf_struct->y, num_particles * sizeof(float));
+    H5B_MALLOC(buf_struct->z, num_particles * sizeof(float));
+    H5B_MALLOC(buf_struct->px, num_particles * sizeof(float));
+    H5B_MALLOC(buf_struct->py, num_particles * sizeof(float));
+    H5B_MALLOC(buf_struct->pz, num_particles * sizeof(float));
+    H5B_MALLOC(buf_struct->id_1, num_particles * sizeof(int));
+    H5B_MALLOC(buf_struct->id_2, num_particles * sizeof(float));
     return buf_struct;
 }
 

--- a/commons/h5bench_util.h
+++ b/commons/h5bench_util.h
@@ -8,9 +8,54 @@
 #ifndef COMMONS_H5BENCH_UTIL_H_
 #define COMMONS_H5BENCH_UTIL_H_
 
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+
 #define DEBUG_PRINT                                                                                          \
     printf("%s:%d\n", __func__, __LINE__);                                                                   \
     fflush(stdout);
+
+/*
+ * Abort the process with a final message. MPI-aware: if MPI has been
+ * initialized (and not yet finalized), uses MPI_Abort so the whole job tears
+ * down rather than leaving ranks orphaned. Otherwise falls back to abort().
+ * Always terminates — safe to call from macros that want a non-returning error.
+ */
+void h5bench_die(const char *msg);
+
+/*
+ * Abort-on-failure helpers. These trade recoverability for simplicity: any
+ * malloc/HDF5 failure becomes a fatal, logged error with file/line context
+ * instead of a silent NULL/invalid-id propagating into later code.
+ */
+#define H5B_MALLOC(ptr, size)                                                                                \
+    do {                                                                                                     \
+        size_t __h5b_sz = (size_t)(size);                                                                    \
+        (ptr)           = malloc(__h5b_sz);                                                                  \
+        if ((ptr) == NULL) {                                                                                 \
+            fprintf(stderr, "h5bench: malloc(%zu) failed at %s:%d\n", __h5b_sz, __FILE__, __LINE__);         \
+            h5bench_die("out of memory");                                                                    \
+        }                                                                                                    \
+    } while (0)
+
+#define H5B_CHECK_HID(hid, name)                                                                             \
+    do {                                                                                                     \
+        if ((hid) < 0) {                                                                                     \
+            fprintf(stderr, "h5bench: HDF5 call '%s' returned invalid id at %s:%d\n", (name), __FILE__,      \
+                    __LINE__);                                                                               \
+            h5bench_die(NULL);                                                                               \
+        }                                                                                                    \
+    } while (0)
+
+#define H5B_CHECK_HERR(herr, name)                                                                           \
+    do {                                                                                                     \
+        if ((herr) < 0) {                                                                                    \
+            fprintf(stderr, "h5bench: HDF5 call '%s' returned error at %s:%d\n", (name), __FILE__,           \
+                    __LINE__);                                                                               \
+            h5bench_die(NULL);                                                                               \
+        }                                                                                                    \
+    } while (0)
 // Maximal line length of the config file
 #define CFG_LINE_LEN_MAX 510
 #define CFG_DELIMS       "=\n"

--- a/h5bench_patterns/h5bench_read.c
+++ b/h5bench_patterns/h5bench_read.c
@@ -100,13 +100,21 @@ read_h5_data(time_step *ts, hid_t loc, hid_t *dset_ids, hid_t filespace, hid_t m
     t1 = get_time_usec();
 
     dset_ids[0] = H5Dopen_async(loc, "x", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[0], "H5Dopen_async(x)");
     dset_ids[1] = H5Dopen_async(loc, "y", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[1], "H5Dopen_async(y)");
     dset_ids[2] = H5Dopen_async(loc, "z", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[2], "H5Dopen_async(z)");
     dset_ids[3] = H5Dopen_async(loc, "id_1", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[3], "H5Dopen_async(id_1)");
     dset_ids[4] = H5Dopen_async(loc, "id_2", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[4], "H5Dopen_async(id_2)");
     dset_ids[5] = H5Dopen_async(loc, "px", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[5], "H5Dopen_async(px)");
     dset_ids[6] = H5Dopen_async(loc, "py", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[6], "H5Dopen_async(py)");
     dset_ids[7] = H5Dopen_async(loc, "pz", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[7], "H5Dopen_async(pz)");
 
     t2 = get_time_usec();
 
@@ -405,11 +413,14 @@ _set_dataspace_seq_3D(hid_t *filespace_in_out, hid_t *memspace_out, unsigned lon
 hid_t
 get_filespace(hid_t file_id)
 {
-    char *grp_name  = "/Timestep_0";
-    char *ds_name   = "px";
-    hid_t gid       = H5Gopen2(file_id, grp_name, H5P_DEFAULT);
-    hid_t dsid      = H5Dopen2(gid, ds_name, H5P_DEFAULT);
+    char *grp_name = "/Timestep_0";
+    char *ds_name  = "px";
+    hid_t gid      = H5Gopen2(file_id, grp_name, H5P_DEFAULT);
+    H5B_CHECK_HID(gid, "H5Gopen2(/Timestep_0)");
+    hid_t dsid = H5Dopen2(gid, ds_name, H5P_DEFAULT);
+    H5B_CHECK_HID(dsid, "H5Dopen2(px)");
     hid_t filespace = H5Dget_space(dsid);
+    H5B_CHECK_HID(filespace, "H5Dget_space");
     H5Dclose(dsid);
     H5Gclose(gid);
     return filespace;
@@ -523,7 +534,6 @@ _run_benchmark_read(hid_t file_id, hid_t fapl, hid_t gapl, hid_t filespace, benc
         sprintf(grp_name, "Timestep_%d", ts_index);
         time_step *ts = &(MEM_MONITOR->time_steps[ts_index]);
         MEM_MONITOR->mem_used += ts->mem_size;
-        assert(ts);
 
         if (params.cnt_time_step_delay > 0) {
             if (ts_index > params.cnt_time_step_delay - 1) // delayed close on all ids of the previous ts
@@ -534,6 +544,7 @@ _run_benchmark_read(hid_t file_id, hid_t fapl, hid_t gapl, hid_t filespace, benc
         t1 = get_time_usec();
 
         ts->grp_id = H5Gopen_async(file_id, grp_name, gapl, ts->es_meta_create);
+        H5B_CHECK_HID(ts->grp_id, "H5Gopen_async");
 
         t2         = get_time_usec();
         meta_time3 = (t2 - t1);
@@ -613,7 +624,12 @@ main(int argc, char *argv[])
 {
     int mpi_thread_lvl_provided = -1;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_thread_lvl_provided);
-    assert(MPI_THREAD_MULTIPLE == mpi_thread_lvl_provided);
+    if (mpi_thread_lvl_provided != MPI_THREAD_MULTIPLE) {
+        fprintf(stderr, "h5bench_read: MPI implementation does not provide MPI_THREAD_MULTIPLE "
+                        "(got level %d)\n",
+                mpi_thread_lvl_provided);
+        h5bench_die(NULL);
+    }
     MPI_Comm_rank(MPI_COMM_WORLD, &MY_RANK);
     MPI_Comm_size(MPI_COMM_WORLD, &NUM_RANKS);
     int            sleep_time = 0;
@@ -656,7 +672,8 @@ main(int argc, char *argv[])
 
     hsize_t dims[64] = {0};
 
-    hid_t         file_id         = H5Fopen(file_name, H5F_ACC_RDONLY, fapl);
+    hid_t file_id = H5Fopen(file_name, H5F_ACC_RDONLY, fapl);
+    H5B_CHECK_HID(file_id, "H5Fopen");
     hid_t         filespace       = get_filespace(file_id);
     int           dims_cnt        = H5Sget_simple_extent_dims(filespace, dims, NULL);
     unsigned long total_particles = 1;
@@ -715,10 +732,10 @@ main(int argc, char *argv[])
         printf("Number of particles available per rank: %llu \n", NUM_PARTICLES);
     }
 
-    data_time_per_step          = malloc(NUM_TIMESTEPS * sizeof(unsigned long));
-    metadata_time_per_step      = malloc(NUM_TIMESTEPS * sizeof(unsigned long));
-    data_wait_time_per_step     = malloc(NUM_TIMESTEPS * sizeof(unsigned long));
-    metadata_wait_time_per_step = malloc(NUM_TIMESTEPS * sizeof(unsigned long));
+    H5B_MALLOC(data_time_per_step, NUM_TIMESTEPS * sizeof(unsigned long));
+    H5B_MALLOC(metadata_time_per_step, NUM_TIMESTEPS * sizeof(unsigned long));
+    H5B_MALLOC(data_wait_time_per_step, NUM_TIMESTEPS * sizeof(unsigned long));
+    H5B_MALLOC(metadata_wait_time_per_step, NUM_TIMESTEPS * sizeof(unsigned long));
 
     MPI_Barrier(MPI_COMM_WORLD);
 

--- a/h5bench_patterns/h5bench_read.c
+++ b/h5bench_patterns/h5bench_read.c
@@ -625,8 +625,9 @@ main(int argc, char *argv[])
     int mpi_thread_lvl_provided = -1;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_thread_lvl_provided);
     if (mpi_thread_lvl_provided != MPI_THREAD_MULTIPLE) {
-        fprintf(stderr, "h5bench_read: MPI implementation does not provide MPI_THREAD_MULTIPLE "
-                        "(got level %d)\n",
+        fprintf(stderr,
+                "h5bench_read: MPI implementation does not provide MPI_THREAD_MULTIPLE "
+                "(got level %d)\n",
                 mpi_thread_lvl_provided);
         h5bench_die(NULL);
     }

--- a/h5bench_patterns/h5bench_read.c
+++ b/h5bench_patterns/h5bench_read.c
@@ -533,6 +533,7 @@ _run_benchmark_read(hid_t file_id, hid_t fapl, hid_t gapl, hid_t filespace, benc
         meta_time1 = 0, meta_time2 = 0, meta_time3 = 0, meta_time4 = 0, meta_time5 = 0;
         sprintf(grp_name, "Timestep_%d", ts_index);
         time_step *ts = &(MEM_MONITOR->time_steps[ts_index]);
+        assert(ts);
         MEM_MONITOR->mem_used += ts->mem_size;
 
         if (params.cnt_time_step_delay > 0) {

--- a/h5bench_patterns/h5bench_write.c
+++ b/h5bench_patterns/h5bench_write.c
@@ -160,7 +160,8 @@ make_compound_type_separates()
 particle *
 prepare_data_interleaved(long particle_cnt, unsigned long *data_size_out)
 {
-    particle *data_out = (particle *)malloc(particle_cnt * sizeof(particle));
+    particle *data_out;
+    H5B_MALLOC(data_out, particle_cnt * sizeof(particle));
 
     for (long i = 0; i < particle_cnt; i++) {
         data_out[i].id_1 = i;
@@ -179,17 +180,18 @@ prepare_data_interleaved(long particle_cnt, unsigned long *data_size_out)
 data_contig_md *
 prepare_data_contig_1D(unsigned long long particle_cnt, unsigned long *data_size_out)
 {
-    data_contig_md *data_out = (data_contig_md *)malloc(sizeof(data_contig_md));
-    data_out->particle_cnt   = particle_cnt;
+    data_contig_md *data_out;
+    H5B_MALLOC(data_out, sizeof(data_contig_md));
+    data_out->particle_cnt = particle_cnt;
 
-    data_out->x     = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->y     = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->z     = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->px    = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->py    = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->pz    = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->id_1  = (int *)malloc(particle_cnt * sizeof(int));
-    data_out->id_2  = (float *)malloc(particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->x, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->y, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->z, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->px, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->py, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->pz, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->id_1, particle_cnt * sizeof(int));
+    H5B_MALLOC(data_out->id_2, particle_cnt * sizeof(float));
     data_out->dim_1 = particle_cnt;
     data_out->dim_2 = 1;
     data_out->dim_3 = 1;
@@ -219,21 +221,21 @@ prepare_data_contig_2D(unsigned long long particle_cnt, long dim_1, long dim_2, 
                    dim_1, dim_2, dim_1 * dim_2, particle_cnt);
         return NULL;
     }
-    assert(particle_cnt == dim_1 * dim_2);
-    data_contig_md *data_out = (data_contig_md *)malloc(sizeof(data_contig_md));
-    data_out->particle_cnt   = particle_cnt;
-    data_out->dim_1          = dim_1;
-    data_out->dim_2          = dim_2;
-    data_out->dim_3          = 1;
+    data_contig_md *data_out;
+    H5B_MALLOC(data_out, sizeof(data_contig_md));
+    data_out->particle_cnt = particle_cnt;
+    data_out->dim_1        = dim_1;
+    data_out->dim_2        = dim_2;
+    data_out->dim_3        = 1;
 
-    data_out->x    = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->y    = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->z    = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->px   = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->py   = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->pz   = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->id_1 = (int *)malloc(particle_cnt * sizeof(int));
-    data_out->id_2 = (float *)malloc(particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->x, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->y, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->z, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->px, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->py, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->pz, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->id_1, particle_cnt * sizeof(int));
+    H5B_MALLOC(data_out->id_2, particle_cnt * sizeof(float));
 
     long idx = 0;
     for (long i1 = 0; i1 < dim_1; i1++) {
@@ -266,20 +268,20 @@ prepare_data_contig_3D(unsigned long long particle_cnt, long dim_1, long dim_2, 
         return NULL;
     }
 
-    assert(particle_cnt == dim_1 * dim_2 * dim_3);
-    data_contig_md *data_out = (data_contig_md *)malloc(sizeof(data_contig_md));
-    data_out->particle_cnt   = particle_cnt;
-    data_out->dim_1          = dim_1;
-    data_out->dim_2          = dim_2;
-    data_out->dim_3          = dim_3;
-    data_out->x              = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->y              = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->z              = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->px             = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->py             = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->pz             = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->id_1           = (int *)malloc(particle_cnt * sizeof(int));
-    data_out->id_2           = (float *)malloc(particle_cnt * sizeof(float));
+    data_contig_md *data_out;
+    H5B_MALLOC(data_out, sizeof(data_contig_md));
+    data_out->particle_cnt = particle_cnt;
+    data_out->dim_1        = dim_1;
+    data_out->dim_2        = dim_2;
+    data_out->dim_3        = dim_3;
+    H5B_MALLOC(data_out->x, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->y, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->z, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->px, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->py, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->pz, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->id_1, particle_cnt * sizeof(int));
+    H5B_MALLOC(data_out->id_2, particle_cnt * sizeof(float));
     long idx                 = 0;
     for (long i1 = 0; i1 < dim_1; i1++) {
         for (long i2 = 0; i2 < dim_2; i2++) {
@@ -458,20 +460,28 @@ data_write_contig_contig_MD_array(time_step *ts, hid_t loc, hid_t *dset_ids, hid
 
     dset_ids[0] = H5Dcreate_async(loc, "x", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[0], "H5Dcreate_async(x)");
     dset_ids[1] = H5Dcreate_async(loc, "y", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[1], "H5Dcreate_async(y)");
     dset_ids[2] = H5Dcreate_async(loc, "z", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[2], "H5Dcreate_async(z)");
     dset_ids[3] = H5Dcreate_async(loc, "px", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[3], "H5Dcreate_async(px)");
     dset_ids[4] = H5Dcreate_async(loc, "py", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[4], "H5Dcreate_async(py)");
     dset_ids[5] = H5Dcreate_async(loc, "pz", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[5], "H5Dcreate_async(pz)");
     dset_ids[6] = H5Dcreate_async(loc, "id_1", H5T_NATIVE_INT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[6], "H5Dcreate_async(id_1)");
     dset_ids[7] = H5Dcreate_async(loc, "id_2", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[7], "H5Dcreate_async(id_2)");
 
     unsigned t2 = get_time_usec();
 
@@ -516,6 +526,7 @@ data_write_contig_to_interleaved(time_step *ts, hid_t loc, hid_t *dset_ids, hid_
     unsigned t1 = get_time_usec();
     dset_ids[0] = H5Dcreate_async(loc, "particles", PARTICLE_COMPOUND_TYPE, filespace, H5P_DEFAULT, dcpl,
                                   H5P_DEFAULT, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[0], "H5Dcreate_async(particles)");
 
     unsigned t2 = get_time_usec();
     ierr = H5Dwrite_async(dset_ids[0], PARTICLE_COMPOUND_TYPE_SEPARATES[0], memspace, filespace, plist_id,
@@ -612,6 +623,7 @@ data_write_interleaved_to_interleaved(time_step *ts, hid_t loc, hid_t *dset_ids,
     unsigned t1 = get_time_usec();
     dset_ids[0] = H5Dcreate_async(loc, "particles", PARTICLE_COMPOUND_TYPE, filespace, H5P_DEFAULT, dcpl,
                                   H5P_DEFAULT, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[0], "H5Dcreate_async(particles)");
 
     unsigned t2 = get_time_usec();
     ierr        = H5Dwrite_async(dset_ids[0], PARTICLE_COMPOUND_TYPE, memspace, filespace, plist_id, data_in,
@@ -766,7 +778,6 @@ _run_benchmark_write(bench_params params, hid_t file_id, hid_t fapl, hid_t files
         MEM_MONITOR->mem_used += ts->mem_size;
 
         sprintf(grp_name, "Timestep_%d", ts_index);
-        assert(ts);
 
         if (params.cnt_time_step_delay > 0) {
             if (ts_index > params.cnt_time_step_delay - 1) // delayed close on all ids of the previous ts
@@ -982,7 +993,12 @@ main(int argc, char *argv[])
 {
     int mpi_thread_lvl_provided = -1;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_thread_lvl_provided);
-    assert(MPI_THREAD_MULTIPLE == mpi_thread_lvl_provided);
+    if (mpi_thread_lvl_provided != MPI_THREAD_MULTIPLE) {
+        fprintf(stderr, "h5bench_write: MPI implementation does not provide MPI_THREAD_MULTIPLE "
+                        "(got level %d)\n",
+                mpi_thread_lvl_provided);
+        h5bench_die(NULL);
+    }
     MPI_Comm_rank(MPI_COMM_WORLD, &MY_RANK);
     MPI_Comm_size(MPI_COMM_WORLD, &NUM_RANKS);
     MPI_Comm           comm               = MPI_COMM_WORLD;
@@ -1059,10 +1075,10 @@ main(int argc, char *argv[])
     unsigned long data_size             = 0;
     unsigned long data_preparation_time = 0;
 
-    data_time_per_step          = malloc(NUM_TIMESTEPS * sizeof(unsigned long));
-    metadata_time_per_step      = malloc(NUM_TIMESTEPS * sizeof(unsigned long));
-    data_wait_time_per_step     = malloc(NUM_TIMESTEPS * sizeof(unsigned long));
-    metadata_wait_time_per_step = malloc(NUM_TIMESTEPS * sizeof(unsigned long));
+    H5B_MALLOC(data_time_per_step, NUM_TIMESTEPS * sizeof(unsigned long));
+    H5B_MALLOC(metadata_time_per_step, NUM_TIMESTEPS * sizeof(unsigned long));
+    H5B_MALLOC(data_wait_time_per_step, NUM_TIMESTEPS * sizeof(unsigned long));
+    H5B_MALLOC(metadata_wait_time_per_step, NUM_TIMESTEPS * sizeof(unsigned long));
 
     MPI_Barrier(MPI_COMM_WORLD);
 
@@ -1106,6 +1122,7 @@ main(int argc, char *argv[])
     else {
         file_id = H5Fcreate_async(output_file, H5F_ACC_TRUNC, H5P_DEFAULT, fapl, 0);
     }
+    H5B_CHECK_HID(file_id, "H5Fcreate_async");
     unsigned long tfopen_end = get_time_usec();
 
     if (MY_RANK == 0)

--- a/h5bench_patterns/h5bench_write.c
+++ b/h5bench_patterns/h5bench_write.c
@@ -282,7 +282,7 @@ prepare_data_contig_3D(unsigned long long particle_cnt, long dim_1, long dim_2, 
     H5B_MALLOC(data_out->pz, particle_cnt * sizeof(float));
     H5B_MALLOC(data_out->id_1, particle_cnt * sizeof(int));
     H5B_MALLOC(data_out->id_2, particle_cnt * sizeof(float));
-    long idx                 = 0;
+    long idx = 0;
     for (long i1 = 0; i1 < dim_1; i1++) {
         for (long i2 = 0; i2 < dim_2; i2++) {
             for (long i3 = 0; i3 < dim_3; i3++) {
@@ -994,8 +994,9 @@ main(int argc, char *argv[])
     int mpi_thread_lvl_provided = -1;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_thread_lvl_provided);
     if (mpi_thread_lvl_provided != MPI_THREAD_MULTIPLE) {
-        fprintf(stderr, "h5bench_write: MPI implementation does not provide MPI_THREAD_MULTIPLE "
-                        "(got level %d)\n",
+        fprintf(stderr,
+                "h5bench_write: MPI implementation does not provide MPI_THREAD_MULTIPLE "
+                "(got level %d)\n",
                 mpi_thread_lvl_provided);
         h5bench_die(NULL);
     }

--- a/h5bench_patterns/h5bench_write.c
+++ b/h5bench_patterns/h5bench_write.c
@@ -775,6 +775,7 @@ _run_benchmark_write(bench_params params, hid_t file_id, hid_t fapl, hid_t files
     for (int ts_index = 0; ts_index < timestep_cnt; ts_index++) {
         meta_time1 = 0, meta_time2 = 0, meta_time3 = 0, meta_time4 = 0, meta_time5 = 0;
         time_step *ts = &(MEM_MONITOR->time_steps[ts_index]);
+        assert(ts);
         MEM_MONITOR->mem_used += ts->mem_size;
 
         sprintf(grp_name, "Timestep_%d", ts_index);


### PR DESCRIPTION
## Summary

Continue repository-wide cleanup, first half of the correctness sweep in: `h5bench_write` and `h5bench_read` binaries plus the shared `commons/` library.

New helpers in `commons/h5bench_util.{h,c}`:

- `H5B_MALLOC(ptr, size)`: malloc + NULL check + logged fatal error.
- `H5B_CHECK_HID(hid, name)`: assert `hid_t >= 0`; logs the call name + `__FILE__:__LINE__` on failure.
- `H5B_CHECK_HERR(herr, name)`: same pattern for `herr_t`.
- `h5bench_die(msg)`: MPI-aware termination: `MPI_Abort` when MPI is live, `abort()` otherwise.

Silent `NULL` and `H5I_INVALID_HID` propagation is the dominant failure mode in these benchmarks today; the macros turn each site into a fatal, logged error with file/line and call-name context instead of a crash deep in downstream HDF5 code.

### Sites swept

- `commons/h5bench_util.c`: all 16 mallocs in `prepare_contig_memory` / `prepare_contig_memory_multi_dim`.
- `h5bench_patterns/h5bench_write.c`:
  - mallocs in `prepare_data_interleaved` and the three `prepare_data_contig_{1,2,3}D` helpers, plus the four timing-array mallocs in `main`.
  - every `H5Dcreate_async` (contig 8-dataset path + both compound-type paths) and `H5Fcreate_async`.
  - `assert(MPI_THREAD_MULTIPLE == ...)` → logged `h5bench_die`. The assert silently became a no-op under `-DNDEBUG` and would have masked a real failure when the MPI implementation refused `MPI_THREAD_MULTIPLE`.
  - dropped the redundant `assert(ts)` inside the timestep loop (`ts = &MEM_MONITOR->time_steps[ts_index]` is always non-NULL).
- `h5bench_patterns/h5bench_read.c`: matching sweep — `H5Dopen_async` loop, `H5Gopen2`/`H5Dopen2`/`H5Dget_space` in `get_filespace`, `H5Gopen_async` in the timestep loop, `H5Fopen` at main, timing-array mallocs, same assert replacements.

### Not in scope (deferred)

- The remaining four pattern files (`h5bench_append.c`, `h5bench_overwrite.c`, `h5bench_write_unlimited.c`, `h5bench_write_normal_dist.c`) share the same patterns and are covered in a mechanical follow-up PR (Wave A part 2b).
- The structural leak in `_prepare_data` where filespace/memspace are left open on failure — belongs to Wave C (core refactor).
- `sprintf` → `snprintf` sweep — Wave A part 3.

### Dependency

Merges cleanly on top of `wave-a-cleanup` (#151); can be reviewed and merged independently.

## Test plan

- [x] CI green across the HDF5 version matrix (behaviour change is confined to previously-silent failure paths).
- [x] Spot-check: force a bogus output path so `H5Fcreate_async` fails; confirm the new message fires and the rank aborts via `MPI_Abort`.
- [x] Spot-check: run on an MPI build without `MPI_THREAD_MULTIPLE`; confirm the new diagnostic fires instead of a bare `assert`.