### PR TITLE
Replace sprintf with snprintf across h5bench-owned code

### DIFF
--- a/exerciser/h5bench_exerciser.c
+++ b/exerciser/h5bench_exerciser.c
@@ -297,7 +297,7 @@ main(int argc, char *argv[])
     struct timeval time;
     gettimeofday(&time, NULL);
     srand(((unsigned int)time.tv_sec * 1000) + ((unsigned int)time.tv_usec / 1000));
-    sprintf(testFileName, "hdf5TestFile-%d", rand());
+    snprintf(testFileName, sizeof(testFileName), "hdf5TestFile-%d", rand());
     MPI_Bcast(testFileName, NAME_LENGTH, MPI_CHAR, 0, comm);
     char dataSetName1[NAME_LENGTH] = "hdf5DataSet1";
 
@@ -534,9 +534,9 @@ main(int argc, char *argv[])
                 MPI_Barrier(comm);
                 startTime = MPI_Wtime();
                 for (i = 0; i < NUM_ATTRIBUTES; i++) {
-                    sprintf(attr1Buf, "This is my attribute string number %d", i);
+                    snprintf(attr1Buf, sizeof(attr1Buf), "This is my attribute string number %d", i);
                     attr1DS = H5Screate_simple(1, attr1Dims, NULL);
-                    sprintf(attributeName, "Attribute %d Name", i);
+                    snprintf(attributeName, sizeof(attributeName), "Attribute %d Name", i);
                     attr1id = H5Acreate(topgroupid, attributeName, H5T_NATIVE_CHAR, attr1DS, H5P_DEFAULT,
                                         H5P_DEFAULT);
                     rc      = H5Awrite(attr1id, H5T_NATIVE_CHAR, attr1Buf);
@@ -583,7 +583,8 @@ main(int argc, char *argv[])
             H5Sselect_hyperslab(fileDataSpace, H5S_SELECT_SET, fileStart, fileStride, fileCount, fileBlock);
 
             /* create the file dataset */
-            sprintf(dataSetName1, "hdf5DataSet1-iter%d-size%d", loopIter, NumDoubleElements);
+            snprintf(dataSetName1, sizeof(dataSetName1), "hdf5DataSet1-iter%d-size%d", loopIter,
+                     NumDoubleElements);
 
             MPI_Barrier(comm);
             startTime = MPI_Wtime();

--- a/h5bench_patterns/h5bench_append.c
+++ b/h5bench_patterns/h5bench_append.c
@@ -424,7 +424,7 @@ _run_benchmark_modify(hid_t file_id, hid_t fapl, hid_t gapl, hid_t filespace, be
     int           dset_cnt = 8;
     for (int ts_index = 0; ts_index < nts; ts_index++) {
         meta_time1 = 0, meta_time2 = 0, meta_time3 = 0, meta_time4 = 0, meta_time5 = 0;
-        sprintf(grp_name, "Timestep_%d", ts_index);
+        snprintf(grp_name, sizeof(grp_name), "Timestep_%d", ts_index);
         time_step *ts = &(MEM_MONITOR->time_steps[ts_index]);
         MEM_MONITOR->mem_used += ts->mem_size;
         assert(ts);

--- a/h5bench_patterns/h5bench_overwrite.c
+++ b/h5bench_patterns/h5bench_overwrite.c
@@ -400,7 +400,7 @@ _run_benchmark_modify(hid_t file_id, hid_t fapl, hid_t gapl, hid_t filespace, be
     int           dset_cnt = 8;
     for (int ts_index = 0; ts_index < nts; ts_index++) {
         meta_time1 = 0, meta_time2 = 0, meta_time3 = 0, meta_time4 = 0, meta_time5 = 0;
-        sprintf(grp_name, "Timestep_%d", ts_index);
+        snprintf(grp_name, sizeof(grp_name), "Timestep_%d", ts_index);
         time_step *ts = &(MEM_MONITOR->time_steps[ts_index]);
         MEM_MONITOR->mem_used += ts->mem_size;
         assert(ts);

--- a/h5bench_patterns/h5bench_read.c
+++ b/h5bench_patterns/h5bench_read.c
@@ -520,7 +520,7 @@ _run_benchmark_read(hid_t file_id, hid_t fapl, hid_t gapl, hid_t filespace, benc
     int           dset_cnt = 8;
     for (int ts_index = 0; ts_index < nts; ts_index++) {
         meta_time1 = 0, meta_time2 = 0, meta_time3 = 0, meta_time4 = 0, meta_time5 = 0;
-        sprintf(grp_name, "Timestep_%d", ts_index);
+        snprintf(grp_name, sizeof(grp_name), "Timestep_%d", ts_index);
         time_step *ts = &(MEM_MONITOR->time_steps[ts_index]);
         MEM_MONITOR->mem_used += ts->mem_size;
         assert(ts);

--- a/h5bench_patterns/h5bench_write.c
+++ b/h5bench_patterns/h5bench_write.c
@@ -765,7 +765,7 @@ _run_benchmark_write(bench_params params, hid_t file_id, hid_t fapl, hid_t files
         time_step *ts = &(MEM_MONITOR->time_steps[ts_index]);
         MEM_MONITOR->mem_used += ts->mem_size;
 
-        sprintf(grp_name, "Timestep_%d", ts_index);
+        snprintf(grp_name, sizeof(grp_name), "Timestep_%d", ts_index);
         assert(ts);
 
         if (params.cnt_time_step_delay > 0) {
@@ -1098,8 +1098,8 @@ main(int argc, char *argv[])
     unsigned long tfopen_start = get_time_usec();
     if (params.file_per_proc) {
         char mpi_rank_output_file_path[4096];
-        sprintf(mpi_rank_output_file_path, "%s/rank_%d_%s", get_dir_from_path(output_file), MY_RANK,
-                get_file_name_from_path(output_file));
+        snprintf(mpi_rank_output_file_path, sizeof(mpi_rank_output_file_path), "%s/rank_%d_%s",
+                 get_dir_from_path(output_file), MY_RANK, get_file_name_from_path(output_file));
 
         file_id = H5Fcreate_async(mpi_rank_output_file_path, H5F_ACC_TRUNC, H5P_DEFAULT, fapl, 0);
     }

--- a/h5bench_patterns/h5bench_write_normal_dist.c
+++ b/h5bench_patterns/h5bench_write_normal_dist.c
@@ -799,7 +799,7 @@ _run_benchmark_write(bench_params params, hid_t file_id, hid_t fapl, hid_t files
         time_step *ts = &(MEM_MONITOR->time_steps[ts_index]);
         MEM_MONITOR->mem_used += ts->mem_size;
         //        print_mem_bound(MEM_MONITOR);
-        sprintf(grp_name, "Timestep_%d", ts_index);
+        snprintf(grp_name, sizeof(grp_name), "Timestep_%d", ts_index);
         assert(ts);
 
         if (params.cnt_time_step_delay > 0) {
@@ -1139,8 +1139,8 @@ main(int argc, char *argv[])
     unsigned long tfopen_start = get_time_usec();
     if (params.file_per_proc) {
         char mpi_rank_output_file_path[4096];
-        sprintf(mpi_rank_output_file_path, "%s/rank_%d_%s", get_dir_from_path(output_file), MY_RANK,
-                get_file_name_from_path(output_file));
+        snprintf(mpi_rank_output_file_path, sizeof(mpi_rank_output_file_path), "%s/rank_%d_%s",
+                 get_dir_from_path(output_file), MY_RANK, get_file_name_from_path(output_file));
 
         file_id = H5Fcreate_async(mpi_rank_output_file_path, H5F_ACC_TRUNC, H5P_DEFAULT, fapl, 0);
     }

--- a/h5bench_patterns/h5bench_write_unlimited.c
+++ b/h5bench_patterns/h5bench_write_unlimited.c
@@ -734,7 +734,7 @@ _run_benchmark_write(bench_params params, hid_t file_id, hid_t fapl, hid_t files
         time_step *ts = &(MEM_MONITOR->time_steps[ts_index]);
         MEM_MONITOR->mem_used += ts->mem_size;
         //        print_mem_bound(MEM_MONITOR);
-        sprintf(grp_name, "Timestep_%d", ts_index);
+        snprintf(grp_name, sizeof(grp_name), "Timestep_%d", ts_index);
         assert(ts);
 
         if (params.cnt_time_step_delay > 0) {
@@ -1038,8 +1038,8 @@ main(int argc, char *argv[])
     unsigned long tfopen_start = get_time_usec();
     if (params.file_per_proc) {
         char mpi_rank_output_file_path[4096];
-        sprintf(mpi_rank_output_file_path, "%s/rank_%d_%s", get_dir_from_path(output_file), MY_RANK,
-                get_file_name_from_path(output_file));
+        snprintf(mpi_rank_output_file_path, sizeof(mpi_rank_output_file_path), "%s/rank_%d_%s",
+                 get_dir_from_path(output_file), MY_RANK, get_file_name_from_path(output_file));
         file_id = H5Fcreate_async(mpi_rank_output_file_path, H5F_ACC_TRUNC, H5P_DEFAULT, fapl, 0);
     }
     else {

--- a/metadata_stress/hdf5_iotest.c
+++ b/metadata_stress/hdf5_iotest.c
@@ -145,7 +145,7 @@ main(int argc, char *argv[])
                 {
                     for (istep = 0; istep < config.steps; ++istep) {
                         create_time -= MPI_Wtime();
-                        sprintf(path, "step=%d", istep);
+                        snprintf(path, sizeof(path), "step=%d", istep);
                         assert((dset = create_dataset(&config, file, path)) >= 0);
                         create_time += MPI_Wtime();
 
@@ -167,7 +167,7 @@ main(int argc, char *argv[])
                 {
                     for (istep = 0; istep < config.steps; ++istep) {
                         for (iarray = 0; iarray < config.arrays; ++iarray) {
-                            sprintf(path, "array=%d", iarray);
+                            snprintf(path, sizeof(path), "array=%d", iarray);
                             if (istep == 0) {
                                 create_time -= MPI_Wtime();
                                 assert((dset = create_dataset(&config, file, path)) >= 0);
@@ -201,8 +201,9 @@ main(int argc, char *argv[])
                     for (iarray = 0; iarray < config.arrays; ++iarray) {
                         create_time -= MPI_Wtime();
                         /* group per step or array of 2D datasets */
-                        sprintf(path, (step_first_flg ? "step=%d/array=%d" : "array=%d/step=%d"),
-                                (step_first_flg ? istep : iarray), (step_first_flg ? iarray : istep));
+                        snprintf(path, sizeof(path),
+                                 (step_first_flg ? "step=%d/array=%d" : "array=%d/step=%d"),
+                                 (step_first_flg ? istep : iarray), (step_first_flg ? iarray : istep));
                         assert((dset = create_dataset(&config, file, path)) >= 0);
                         create_time += MPI_Wtime();
 
@@ -256,7 +257,7 @@ main(int argc, char *argv[])
                 if (step_first_flg) /* dataset per step */
                 {
                     for (istep = 0; istep < config.steps; ++istep) {
-                        sprintf(path, "step=%d", istep);
+                        snprintf(path, sizeof(path), "step=%d", istep);
                         assert((dset = H5Dopen(file, path, H5P_DEFAULT)) >= 0);
                         assert((fspace = H5Dget_space(dset)) >= 0);
 
@@ -276,7 +277,7 @@ main(int argc, char *argv[])
                 {
                     for (istep = 0; istep < config.steps; ++istep) {
                         for (iarray = 0; iarray < config.arrays; ++iarray) {
-                            sprintf(path, "array=%d", iarray);
+                            snprintf(path, sizeof(path), "array=%d", iarray);
                             assert((dset = H5Dopen(file, path, H5P_DEFAULT)) >= 0);
                             assert((fspace = H5Dget_space(dset)) >= 0);
                             create_selection(&config, fspace, my_proc_row, my_proc_col, istep, iarray);
@@ -295,8 +296,9 @@ main(int argc, char *argv[])
                 for (istep = 0; istep < config.steps; ++istep) {
                     for (iarray = 0; iarray < config.arrays; ++iarray) {
                         /* group per step or array */
-                        sprintf(path, (step_first_flg ? "step=%d/array=%d" : "array=%d/step=%d"),
-                                (step_first_flg ? istep : iarray), (step_first_flg ? iarray : istep));
+                        snprintf(path, sizeof(path),
+                                 (step_first_flg ? "step=%d/array=%d" : "array=%d/step=%d"),
+                                 (step_first_flg ? istep : iarray), (step_first_flg ? iarray : istep));
 
                         assert((dset = H5Dopen(file, path, H5P_DEFAULT)) >= 0);
 


### PR DESCRIPTION
## Summary

All 19 `sprintf` in h5bench source files now pass an explicit `sizeof(buffer)` limit.

Inputs are currently bounded integers or already-bounded path components, so this is not fixing an active overflow. But the untruncated `sprintf` form left no margin if upstream buffers are ever reused with larger formats, and the new form makes the intent explicit.

### Sites (8 files, 19 calls)

| File | Calls | Buffers |
|------|---:|---|
| `h5bench_patterns/h5bench_{write,read,overwrite,append,write_unlimited,write_normal_dist}.c` | 10 | 6× `grp_name[128]`, 3× `mpi_rank_output_file_path[4096]`, 1× read-path `grp_name` |
| `exerciser/h5bench_exerciser.c` | 4 | `testFileName`, `attr1Buf`, `attributeName`, `dataSetName1` |
| `metadata_stress/hdf5_iotest.c` | 6 | `path[255]` — step/array/compound formats, each appearing twice in the write + read phases (collapsed with `replace_all`) |

### Out of scope

Vendored submodules (`amrex/`, `e3sm/`, `macsio/`) are intentionally not touched — they're upstream code. Their 146 additional `sprintf` calls belong to the upstream projects.

### Dependency

Independent of #151 / #152 / #153 and targets `develop` directly.