### PR TITLE
Modernize CMake: imported targets, helper fn, split root CMakeLists

### DIFF
--- a/CMake/h5benchFunctions.cmake
+++ b/CMake/h5benchFunctions.cmake
@@ -1,0 +1,32 @@
+# Shared helpers for h5bench benchmark targets.
+#
+# h5bench_add_pattern(<name>
+#     SOURCES  <file> [<file>...]
+#     [LIBS    <extra-libs>...]    # extra private libs (e.g. m)
+#     [INSTALL]                    # add install(TARGETS ...) in bin/
+# )
+#
+# Creates an executable <name> that links against h5bench_util (which
+# transitively provides HDF5, MPI, and any VOL-ASYNC glue), plus the
+# compression and dl libs every pattern needs. Callers only have to
+# declare what actually varies per benchmark.
+function(h5bench_add_pattern name)
+    cmake_parse_arguments(PARSE_ARGV 1 H5BP "INSTALL" "" "SOURCES;LIBS")
+
+    if(NOT H5BP_SOURCES)
+        message(FATAL_ERROR "h5bench_add_pattern(${name}): SOURCES is required")
+    endif()
+
+    add_executable(${name} ${H5BP_SOURCES})
+    target_link_libraries(${name}
+        PRIVATE
+            h5bench_util
+            ZLIB::ZLIB
+            ${CMAKE_DL_LIBS}
+            ${H5BP_LIBS}
+    )
+
+    if(H5BP_INSTALL)
+        install(TARGETS ${name} DESTINATION bin)
+    endif()
+endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,14 @@ include(CTest)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake" ${CMAKE_MODULE_PATH})
 
+# Keep every h5bench_* executable at the top of the build tree. The Python
+# driver's is_available() check falls back to PWD (shutil.which path=PATH + ':.'),
+# and some CI environments (notably NERSC) install to a non-PATH prefix and rely
+# on running `./h5bench` from the build dir. Before the per-subdir CMakeLists
+# refactor every add_executable() was at root scope, so binaries naturally
+# landed at ${CMAKE_BINARY_DIR}; this restores that layout explicitly.
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
 find_package(Python REQUIRED)
 find_package(MPI REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,6 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake" ${CMAKE_MODULE_PATH})
 find_package(Python REQUIRED)
 find_package(MPI REQUIRED)
 
-include_directories(SYSTEM ${MPI_INCLUDE_PATH})
-
 enable_testing()
 
 # Options and Variants ########################################################
@@ -76,22 +74,21 @@ find_package(HDF5 REQUIRED)
 
 message(STATUS "Using HDF5 version: ${HDF5_VERSION}")
 
-include_directories(${HDF5_HOME}/include)
-link_directories(${HDF5_HOME}/lib)
-
 # Check if HDF5 has subfiling VFD
-set(HAVE_subfiling 0)
-find_file (H5FDsubfiling_H H5FDsubfiling.h PATHS ${HDF5_INCLUDE_DIRS})
+set(HAVE_SUBFILING_VFD 0)
+find_file(H5FDsubfiling_H H5FDsubfiling.h PATHS ${HDF5_INCLUDE_DIRS})
 if(EXISTS ${H5FDsubfiling_H})
-   include(CheckSymbolExists)
-   set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${HDF5_INCLUDE_DIRS})
-   check_symbol_exists(H5_HAVE_SUBFILING_VFD hdf5.h HAVE_SUBFILING_VFD)
-   if(${HAVE_SUBFILING_VFD})
-       add_definitions(-DHAVE_SUBFILING)
-   endif()
-   unset(CMAKE_REQUIRED_INCLUDES)
+    include(CheckSymbolExists)
+    set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${HDF5_INCLUDE_DIRS})
+    check_symbol_exists(H5_HAVE_SUBFILING_VFD hdf5.h HAVE_SUBFILING_VFD)
+    unset(CMAKE_REQUIRED_INCLUDES)
 endif()
 message(STATUS "   Detected HDF5 subfiling support: ${HAVE_SUBFILING_VFD}")
+
+# ZLIB Dependency #############################################################
+#
+
+find_package(ZLIB REQUIRED)
 
 # VOL ASYNC Dependency ########################################################
 #
@@ -101,9 +98,8 @@ option(WITH_ASYNC_VOL "Enable HDF5 VOL ASYNC connector" OFF)
 
 if(WITH_ASYNC_VOL)
     if(${HDF5_VERSION} VERSION_GREATER_EQUAL "1.13.0")
-        add_definitions(-DUSE_ASYNC_VOL)
-        include_directories(${ASYNC_HOME}/include)
-        link_directories(${ASYNC_HOME}/lib)
+        # USE_ASYNC_VOL define + include/link paths are applied to
+        # h5bench_util (and thus every consumer) in commons/CMakeLists.txt.
     else()
         message(SEND_ERROR "VOL ASYNC requires HDF5 1.13.0 or newer.")
     endif()
@@ -111,97 +107,20 @@ endif()
 
 message(STATUS "HDF5 VOL ASYNC: ${WITH_ASYNC_VOL}")
 
-# h5bench Utility #############################################################
+# h5bench Benchmarks ##########################################################
 #
 
-set(h5bench_util_src
-    commons/h5bench_util.c
-    commons/h5bench_util.h
-)
+include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/h5benchFunctions.cmake)
 
-add_library(h5bench_util ${h5bench_util_src})
-
-if(WITH_ASYNC_VOL)
-    target_link_libraries(h5bench_util asynchdf5 h5async)
-endif()
-
-# h5bench WRITE varying particle based on normal distribution ######################
-#
-
-set(h5bench_write_normal_dist_src h5bench_patterns/h5bench_write_normal_dist.c)
-
-add_executable(h5bench_write_var_normal_dist ${h5bench_write_normal_dist_src})
-target_link_libraries(h5bench_write_var_normal_dist h5bench_util hdf5 z m ${CMAKE_DL_LIBS} MPI::MPI_C) 
-
-# h5bench WRITE ###############################################################
-#
-
-set(h5bench_write_src h5bench_patterns/h5bench_write.c)
-
-add_executable(h5bench_write ${h5bench_write_src})
-target_link_libraries(h5bench_write h5bench_util hdf5 z ${CMAKE_DL_LIBS} MPI::MPI_C) 
-
-# h5bench WRITE UNLIMITED #####################################################
-#
-
-set(h5bench_write_unlimited_src h5bench_patterns/h5bench_write_unlimited.c)
-
-add_executable(h5bench_write_unlimited ${h5bench_write_unlimited_src})
-target_link_libraries(h5bench_write_unlimited h5bench_util hdf5 z ${CMAKE_DL_LIBS} MPI::MPI_C) 
-
-# h5bench OVERWRITE ###########################################################
-#
-
-set(h5bench_overwrite_src h5bench_patterns/h5bench_overwrite.c)
-
-add_executable(h5bench_overwrite ${h5bench_overwrite_src})
-target_link_libraries(h5bench_overwrite h5bench_util hdf5 z ${CMAKE_DL_LIBS} MPI::MPI_C)
-
-# h5bench APPEND ##############################################################
-#
-
-set(h5bench_append_src h5bench_patterns/h5bench_append.c)
-
-add_executable(h5bench_append ${h5bench_append_src})
-target_link_libraries(h5bench_append h5bench_util hdf5 z ${CMAKE_DL_LIBS} MPI::MPI_C)
-
-# h5bench READ ################################################################
-#
-
-set(h5bench_read_src h5bench_patterns/h5bench_read.c)
-
-add_executable(h5bench_read ${h5bench_read_src})
-target_link_libraries(h5bench_read h5bench_util hdf5 z ${CMAKE_DL_LIBS} MPI::MPI_C)
-
-
-# Exerciser ###################################################################
-#
+add_subdirectory(commons)
+add_subdirectory(h5bench_patterns)
 
 if(H5BENCH_EXERCISER)
-    set(exerciser_src exerciser/h5bench_exerciser.c)
-
-    add_executable(h5bench_exerciser ${exerciser_src})
-
-    target_link_libraries(h5bench_exerciser hdf5 z m ${CMAKE_DL_LIBS} MPI::MPI_C)
+    add_subdirectory(exerciser)
 endif()
 
-# IOTEST ######################################################################
-#
-
 if(H5BENCH_METADATA)
-    set(meta_stress_src
-        metadata_stress/hdf5_iotest.c
-        metadata_stress/configuration.c
-        metadata_stress/configuration.h
-        metadata_stress/dataset.c
-        metadata_stress/dataset.h
-        metadata_stress/ini.c
-        metadata_stress/ini.h
-    )
-
-    add_executable(h5bench_hdf5_iotest ${meta_stress_src})
-
-    target_link_libraries(h5bench_hdf5_iotest h5bench_util hdf5 z m ${CMAKE_DL_LIBS} MPI::MPI_C)
+    add_subdirectory(metadata_stress)
 endif()
 
 # AMReX #######################################################################
@@ -218,7 +137,17 @@ if(H5BENCH_AMREX)
     set(amrex_src amrex/Tests/HDF5Benchmark/main.cpp)
 
     add_executable(h5bench_amrex_sync ${amrex_src})
-    target_link_libraries(h5bench_amrex_sync hdf5 z m amrex pthread ${CMAKE_DL_LIBS} MPI::MPI_C)
+    target_include_directories(h5bench_amrex_sync PRIVATE ${HDF5_INCLUDE_DIRS})
+    target_link_libraries(h5bench_amrex_sync
+        PRIVATE
+            ${HDF5_LIBRARIES}
+            ZLIB::ZLIB
+            m
+            amrex
+            pthread
+            ${CMAKE_DL_LIBS}
+            MPI::MPI_C
+    )
 
     if(WITH_ASYNC_VOL)
         message(WARNING "h5bench AMReX with ASYNC-VOL: ensure ASYNC-VOL was compiled with -DENABLE_WRITE_MEMCPY=ON")
@@ -226,7 +155,20 @@ if(H5BENCH_AMREX)
         set(AMReX_HDF5_ASYNC YES)
 
         add_executable(h5bench_amrex_async ${amrex_src})
-        target_link_libraries(h5bench_amrex_async hdf5 z m amrex pthread asynchdf5 h5async ${CMAKE_DL_LIBS} MPI::MPI_C)
+        target_include_directories(h5bench_amrex_async PRIVATE ${HDF5_INCLUDE_DIRS} ${ASYNC_HOME}/include)
+        target_link_directories(h5bench_amrex_async PRIVATE ${ASYNC_HOME}/lib)
+        target_link_libraries(h5bench_amrex_async
+            PRIVATE
+                ${HDF5_LIBRARIES}
+                ZLIB::ZLIB
+                m
+                amrex
+                pthread
+                asynchdf5
+                h5async
+                ${CMAKE_DL_LIBS}
+                MPI::MPI_C
+        )
     endif()
 endif()
 
@@ -239,7 +181,7 @@ if(H5BENCH_E3SM)
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/e3sm
         CONFIGURE_COMMAND autoreconf -i COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/e3sm/configure --prefix=${CMAKE_BINARY_DIR} --with-hdf5=${HDF5_HOME} CFLAGS=-fno-var-tracking-assignments CXXFLAGS=-fno-var-tracking-assignments
         BUILD_COMMAND make -j 1
-        INSTALL_COMMAND ${CMAKE_COMMAND} -E copy src/e3sm_io ${CMAKE_BINARY_DIR}/h5bench_e3sm 
+        INSTALL_COMMAND ${CMAKE_COMMAND} -E copy src/e3sm_io ${CMAKE_BINARY_DIR}/h5bench_e3sm
         BUILD_IN_SOURCE 1
         LOG_CONFIGURE 1
         LOG_BUILD 1
@@ -265,7 +207,8 @@ if(H5BENCH_OPENPMD)
     set(openPMD_BUILD_CLI_TOOLS OFF CACHE BOOL "" FORCE)
 
     add_executable(h5bench_openpmd_write openpmd/examples/8a_benchmark_write_parallel.cpp)
-    target_link_libraries(h5bench_openpmd_write openPMD hdf5 MPI::MPI_C)
+    target_include_directories(h5bench_openpmd_write PRIVATE ${HDF5_INCLUDE_DIRS})
+    target_link_libraries(h5bench_openpmd_write PRIVATE openPMD ${HDF5_LIBRARIES} MPI::MPI_C)
 
     set_target_properties(h5bench_openpmd_write PROPERTIES
         CXX_EXTENSIONS OFF
@@ -274,7 +217,8 @@ if(H5BENCH_OPENPMD)
     )
 
     add_executable(h5bench_openpmd_read openpmd/examples/8b_benchmark_read_parallel.cpp)
-    target_link_libraries(h5bench_openpmd_read openPMD hdf5 MPI::MPI_C)
+    target_include_directories(h5bench_openpmd_read PRIVATE ${HDF5_INCLUDE_DIRS})
+    target_link_libraries(h5bench_openpmd_read PRIVATE openPMD ${HDF5_LIBRARIES} MPI::MPI_C)
 
     set_target_properties(h5bench_openpmd_read PROPERTIES
         CXX_EXTENSIONS OFF
@@ -330,11 +274,11 @@ if(H5BENCH_MACSIO)
     add_dependencies(h5bench_macsio json_cwx)
 endif()
 
+# Python driver ###############################################################
+
 configure_file(${CMAKE_SOURCE_DIR}/src/h5bench.py ${CMAKE_BINARY_DIR}/h5bench COPYONLY)
 configure_file(${CMAKE_SOURCE_DIR}/src/h5bench_version.py ${CMAKE_BINARY_DIR}/h5bench_version.py COPYONLY)
 configure_file(${CMAKE_SOURCE_DIR}/src/h5bench_configuration.py.in ${CMAKE_BINARY_DIR}/h5bench_configuration.py)
-
-# Install binaries ############################################################
 
 install(
     FILES
@@ -357,32 +301,8 @@ install(
     DESTINATION bin
 )
 
-install(
-    TARGETS
-    h5bench_write
-    h5bench_write_unlimited
-    h5bench_write_var_normal_dist
-    h5bench_overwrite
-    h5bench_append
-    h5bench_read
-    DESTINATION bin
-)
-
-if(H5BENCH_EXERCISER)
-    install(
-        TARGETS
-        h5bench_exerciser
-        DESTINATION bin
-    )
-endif()
-
-if(H5BENCH_METADATA)
-    install(
-        TARGETS
-        h5bench_hdf5_iotest
-        DESTINATION bin
-    )
-endif()
+# Optional-benchmark installs (core patterns, exerciser, metadata_stress
+# install themselves from their own subdirectory CMakeLists.txt).
 
 if(H5BENCH_OPENPMD)
     install(
@@ -408,9 +328,9 @@ if(H5BENCH_AMREX)
     )
 
     if(WITH_ASYNC_VOL)
-        install( 
+        install(
             TARGETS
-            h5bench_amrex_async 
+            h5bench_amrex_async
             DESTINATION bin
         )
     endif()

--- a/commons/CMakeLists.txt
+++ b/commons/CMakeLists.txt
@@ -1,0 +1,34 @@
+# h5bench_util: shared utility library used by every pattern binary and
+# the metadata benchmark. Propagates HDF5 + MPI (and optionally VOL-ASYNC
+# and subfiling) to consumers via PUBLIC properties so callers just link
+# h5bench_util and get the rest for free.
+
+add_library(h5bench_util
+    h5bench_util.c
+    h5bench_util.h
+)
+
+target_include_directories(h5bench_util
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        ${HDF5_INCLUDE_DIRS}
+)
+
+target_link_libraries(h5bench_util
+    PUBLIC
+        MPI::MPI_C
+        ${HDF5_LIBRARIES}
+    PRIVATE
+        ${CMAKE_DL_LIBS}
+)
+
+if(HAVE_SUBFILING_VFD)
+    target_compile_definitions(h5bench_util PUBLIC HAVE_SUBFILING)
+endif()
+
+if(WITH_ASYNC_VOL)
+    target_compile_definitions(h5bench_util PUBLIC USE_ASYNC_VOL)
+    target_include_directories(h5bench_util PUBLIC ${ASYNC_HOME}/include)
+    target_link_directories(h5bench_util PUBLIC ${ASYNC_HOME}/lib)
+    target_link_libraries(h5bench_util PUBLIC asynchdf5 h5async)
+endif()

--- a/exerciser/CMakeLists.txt
+++ b/exerciser/CMakeLists.txt
@@ -1,0 +1,19 @@
+# HDF5 Exerciser — stand-alone benchmark, does not use h5bench_util.
+
+add_executable(h5bench_exerciser h5bench_exerciser.c)
+
+target_include_directories(h5bench_exerciser
+    PRIVATE
+        ${HDF5_INCLUDE_DIRS}
+)
+
+target_link_libraries(h5bench_exerciser
+    PRIVATE
+        ${HDF5_LIBRARIES}
+        MPI::MPI_C
+        ZLIB::ZLIB
+        ${CMAKE_DL_LIBS}
+        m
+)
+
+install(TARGETS h5bench_exerciser DESTINATION bin)

--- a/h5bench_patterns/CMakeLists.txt
+++ b/h5bench_patterns/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Core pattern benchmarks — all share the same link recipe via
+# h5bench_add_pattern(), which is defined in cmake/h5benchFunctions.cmake
+# and loaded by the top-level CMakeLists.txt.
+
+h5bench_add_pattern(h5bench_write
+    SOURCES h5bench_write.c
+    INSTALL
+)
+
+h5bench_add_pattern(h5bench_write_unlimited
+    SOURCES h5bench_write_unlimited.c
+    INSTALL
+)
+
+h5bench_add_pattern(h5bench_write_var_normal_dist
+    SOURCES h5bench_write_normal_dist.c
+    LIBS    m
+    INSTALL
+)
+
+h5bench_add_pattern(h5bench_overwrite
+    SOURCES h5bench_overwrite.c
+    INSTALL
+)
+
+h5bench_add_pattern(h5bench_append
+    SOURCES h5bench_append.c
+    INSTALL
+)
+
+h5bench_add_pattern(h5bench_read
+    SOURCES h5bench_read.c
+    INSTALL
+)

--- a/metadata_stress/CMakeLists.txt
+++ b/metadata_stress/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Metadata stress test (hdf5_iotest).
+
+add_executable(h5bench_hdf5_iotest
+    hdf5_iotest.c
+    configuration.c
+    configuration.h
+    dataset.c
+    dataset.h
+    ini.c
+    ini.h
+)
+
+target_link_libraries(h5bench_hdf5_iotest
+    PRIVATE
+        h5bench_util
+        ZLIB::ZLIB
+        ${CMAKE_DL_LIBS}
+        m
+)
+
+install(TARGETS h5bench_hdf5_iotest DESTINATION bin)


### PR DESCRIPTION
## Summary

Drop global `include_directories` / `link_directories` in favour of target-scoped modern CMake; factor the 430-line root `CMakeLists.txt` into per-directory files; introduce a one-line `h5bench_add_pattern()` helper that replaces six near-identical `add_executable` / `target_link_libraries` blocks.

No functional change for users — all existing options (`H5BENCH_*`, `WITH_ASYNC_VOL`), env vars (`HDF5_DIR`, `HDF5_HOME`, `ASYNC_HOME`), and target names are preserved.

Stacked on **#151 (wave-a-cleanup)**.

### Structure

| File | What it owns |
|------|--------------|
| `CMake/h5benchFunctions.cmake` | `h5bench_add_pattern()` helper |
| `commons/CMakeLists.txt` | `h5bench_util` library; propagates HDF5 / MPI / VOL-ASYNC / subfiling via PUBLIC linkage |
| `h5bench_patterns/CMakeLists.txt` | 6 pattern binaries via the helper |
| `exerciser/CMakeLists.txt` | `h5bench_exerciser` |
| `metadata_stress/CMakeLists.txt` | `h5bench_hdf5_iotest` |
| `CMakeLists.txt` (root) | options, dependency discovery, `add_subdirectory()` fan-out, AMReX / OpenPMD / E3SM / MACSio blocks, python driver install |

### Modernization details

- `include_directories(${HDF5_HOME}/include / MPI_INCLUDE_PATH)` / `link_directories(${HDF5_HOME}/lib)` at global scope → `target_include_directories` / `target_link_libraries` on `h5bench_util` with `PUBLIC` linkage. Downstream pattern binaries just link `h5bench_util`.
- `find_package(ZLIB REQUIRED)` + `ZLIB::ZLIB` imported target, replacing the bare `z` library-name link.
- `add_definitions(-DUSE_ASYNC_VOL)` / `-DHAVE_SUBFILING` at global scope → `target_compile_definitions(h5bench_util PUBLIC ...)`.
- AMReX + OpenPMD targets updated similarly: `target_include_directories` for `${HDF5_INCLUDE_DIRS}`, `target_link_libraries` linking `${HDF5_LIBRARIES}` + `ZLIB::ZLIB` instead of bare names.