### PR TITLE
Add JSON schema for configuration files + driver-side validation

### DIFF
--- a/.github/workflows/h5bench-hdf5-develop-test.yml
+++ b/.github/workflows/h5bench-hdf5-develop-test.yml
@@ -36,6 +36,7 @@ jobs:
           git clone --recursive https://github.com/hpc-io/vol-async.git --branch develop /opt/vol-async
 
           python3 -m pip install pytest
+          python3 -m pip install -r tests/requirements.txt
 
       - name: Build HDF5 develop
         run: |

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,23 @@
+# codecov configuration
+#
+# h5bench's test suite is expanding gradually (Wave C-prep in #157
+# added Python-side coverage from ~0% up; the C benchmark binaries
+# themselves are mostly exercised by integration tests, not unit
+# tests, so line-level coverage is inherently modest). The default
+# "auto" target for codecov/patch demands new lines meet or exceed
+# the project average, which is too strict while coverage is still
+# growing.
+#
+# Mark both status checks as informational: codecov continues to
+# annotate PRs with per-line coverage, but does not block merges on
+# a coverage-percentage target. Revisit once project coverage has
+# a stable baseline.
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -241,6 +241,12 @@ You can find several samples of configuration file with all the options in our [
 
 For a description of all the options available in each benchmark, please refer to their entries in the documentation.
 
+The full configuration grammar is captured in a JSON Schema file at ``schemas/h5bench-config.schema.json`` (root of the repository). When the optional ``jsonschema`` Python package is installed (``pip install jsonschema``), the driver validates every config against this schema on startup and rejects unknown keys, wrong-typed values, and out-of-enum settings (for example ``MODE: "BOGUS"`` or ``MEM_PATTERN: "sequential"``) with a precise error message pointing at the offending field. Without ``jsonschema``, the driver falls back to a minimal five-required-keys check and prints a warning.
+
+You can run the schema against a config out-of-band before launching::
+
+   python3 -c "import json, jsonschema; jsonschema.validate(json.load(open('my.json')), json.load(open('schemas/h5bench-config.schema.json')))"
+
 When the ``--debug`` option is enabled, you can expect an output similar to:
 
 .. code-block::

--- a/samples/sync-write-1d-contig-contig-normal-dist.json
+++ b/samples/sync-write-1d-contig-contig-normal-dist.json
@@ -11,7 +11,7 @@
     "directory": "storage",
     "benchmarks": [
         {
-            "benchmark": "write_normal_dist",
+            "benchmark": "write_var_normal_dist",
             "file": "test.h5",
             "configuration": {
                 "MEM_PATTERN": "CONTIG",

--- a/schemas/h5bench-config.schema.json
+++ b/schemas/h5bench-config.schema.json
@@ -1,0 +1,238 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/hpc-io/h5bench/schemas/h5bench-config.schema.json",
+    "title": "h5bench configuration",
+    "description": "Validates the JSON file passed to the h5bench Python driver. Pattern benchmarks (write/read/append/overwrite/write-unlimited/write_var_normal_dist) are strictly typed because the driver translates their keys into argv for the binary; exerciser/metadata/amrex/openpmd/e3sm/macsio carry an opaque configuration object because their binaries parse the keys themselves.",
+    "type": "object",
+    "required": ["mpi", "vol", "file-system", "directory", "benchmarks"],
+    "additionalProperties": true,
+    "properties": {
+        "mpi": { "$ref": "#/$defs/mpiSection" },
+        "vol": { "$ref": "#/$defs/volSection" },
+        "file-system": { "$ref": "#/$defs/fileSystemSection" },
+        "directory": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Output directory for benchmark artifacts (created if missing)."
+        },
+        "benchmarks": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#/$defs/benchmarkEntry" }
+        }
+    },
+    "$defs": {
+        "mpiSection": {
+            "type": "object",
+            "required": ["command"],
+            "additionalProperties": false,
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "enum": ["mpirun", "mpiexec", "srun", "jsrun", "runjob"],
+                    "description": "MPI launcher binary. The driver wires up -np / -n for mpirun/mpiexec/srun automatically when 'configuration' is absent."
+                },
+                "ranks": {
+                    "type": "string",
+                    "pattern": "^\\d+$",
+                    "description": "Rank count as a numeric string. Used only when 'configuration' is absent."
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "Raw extra arguments appended verbatim after the launcher command. When set, overrides the implicit -np <ranks> wiring."
+                }
+            }
+        },
+        "volSection": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "library": {
+                    "type": "string",
+                    "description": "Colon-separated list of directories prepended to LD_LIBRARY_PATH (and DYLD_LIBRARY_PATH) for the run."
+                },
+                "preload": {
+                    "type": "string",
+                    "description": "Colon-separated list of shared objects prepended to LD_PRELOAD."
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Directory exported as HDF5_PLUGIN_PATH so HDF5 finds VOL connectors."
+                },
+                "connector": {
+                    "type": "string",
+                    "description": "Value for HDF5_VOL_CONNECTOR, e.g. 'async under_vol=0;under_info={}'."
+                }
+            }
+        },
+        "fileSystemSection": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lustre": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "stripe-size": { "type": ["string", "integer"] },
+                        "stripe-count": { "type": ["string", "integer"] }
+                    }
+                }
+            }
+        },
+
+        "benchmarkEntry": {
+            "type": "object",
+            "required": ["benchmark"],
+            "properties": {
+                "benchmark": {
+                    "type": "string",
+                    "enum": [
+                        "write",
+                        "write-unlimited",
+                        "overwrite",
+                        "append",
+                        "read",
+                        "write_var_normal_dist",
+                        "exerciser",
+                        "metadata",
+                        "amrex",
+                        "openpmd",
+                        "e3sm",
+                        "macsio"
+                    ]
+                },
+                "file": {
+                    "type": "string",
+                    "description": "Output filename relative to the top-level 'directory'."
+                },
+                "configuration": { "type": "object" }
+            },
+            "oneOf": [
+                { "$ref": "#/$defs/patternBenchmark" },
+                { "$ref": "#/$defs/exerciserBenchmark" },
+                { "$ref": "#/$defs/metadataBenchmark" },
+                { "$ref": "#/$defs/opaqueBenchmark" }
+            ]
+        },
+
+        "patternBenchmark": {
+            "description": "write / write-unlimited / overwrite / append / read / write_var_normal_dist — the driver translates the configuration keys into argv for the h5bench_<pattern> binary, so each key is strictly typed.",
+            "type": "object",
+            "properties": {
+                "benchmark": {
+                    "enum": [
+                        "write",
+                        "write-unlimited",
+                        "overwrite",
+                        "append",
+                        "read",
+                        "write_var_normal_dist"
+                    ]
+                },
+                "file": { "type": "string" },
+                "configuration": { "$ref": "#/$defs/patternConfiguration" }
+            },
+            "required": ["benchmark", "file", "configuration"],
+            "additionalProperties": false
+        },
+
+        "patternConfiguration": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "MEM_PATTERN":     { "enum": ["CONTIG", "INTERLEAVED", "STRIDED"] },
+                "FILE_PATTERN":    { "enum": ["CONTIG", "INTERLEAVED", "STRIDED"] },
+                "MODE":            { "enum": ["SYNC", "ASYNC", "LOG"] },
+                "READ_OPTION":     { "enum": ["FULL", "PARTIAL", "STRIDED", "LDC", "RDC", "CS", "PRL"] },
+                "COLLECTIVE_DATA":     { "enum": ["YES", "NO"] },
+                "COLLECTIVE_METADATA": { "enum": ["YES", "NO"] },
+                "COMPRESS":            { "enum": ["YES", "NO"] },
+                "ALIGN":               { "enum": ["YES", "NO"] },
+
+                "NUM_DIMS":     { "$ref": "#/$defs/dimCount" },
+                "DIM_1":        { "$ref": "#/$defs/numericString" },
+                "DIM_2":        { "$ref": "#/$defs/numericString" },
+                "DIM_3":        { "$ref": "#/$defs/numericString" },
+                "CHUNK_DIM_1":  { "$ref": "#/$defs/numericString" },
+                "CHUNK_DIM_2":  { "$ref": "#/$defs/numericString" },
+                "CHUNK_DIM_3":  { "$ref": "#/$defs/numericString" },
+                "STDEV_DIM_1":  { "$ref": "#/$defs/numericString" },
+
+                "TIMESTEPS":               { "$ref": "#/$defs/numericString" },
+                "DELAYED_CLOSE_TIMESTEPS": { "$ref": "#/$defs/numericString" },
+
+                "STRIDE_SIZE":   { "$ref": "#/$defs/numericString" },
+                "STRIDE_SIZE_2": { "$ref": "#/$defs/numericString" },
+                "STRIDE_SIZE_3": { "$ref": "#/$defs/numericString" },
+                "BLOCK_SIZE":    { "$ref": "#/$defs/numericString" },
+                "BLOCK_SIZE_2":  { "$ref": "#/$defs/numericString" },
+                "BLOCK_SIZE_3":  { "$ref": "#/$defs/numericString" },
+                "BLOCK_CNT":     { "$ref": "#/$defs/numericString" },
+
+                "ALIGN_LEN":       { "$ref": "#/$defs/numericString" },
+                "ALIGN_THRESHOLD": { "$ref": "#/$defs/numericString" },
+
+                "NUM_PARTICLES": {
+                    "type": "string",
+                    "pattern": "^\\d+(\\s+(K|M|G|T)s?)?$",
+                    "description": "Accepts either a plain integer ('1024') or the K/M/G/T suffix form h5bench parses ('1024 Ks')."
+                },
+
+                "EMULATED_COMPUTE_TIME_PER_TIMESTEP": {
+                    "type": "string",
+                    "pattern": "^\\d+\\s+(min|sec|s|ms|us)$",
+                    "description": "<value> <unit>. Unit ∈ {min, sec, s, ms, us}; '0 s' is valid for fast tests."
+                },
+
+                "CSV_FILE": { "type": "string" }
+            }
+        },
+
+        "dimCount": {
+            "type": "string",
+            "enum": ["1", "2", "3"],
+            "description": "Number of dataset dimensions; 1, 2, or 3."
+        },
+
+        "numericString": {
+            "type": "string",
+            "pattern": "^\\d+$",
+            "description": "h5bench config historically uses string-quoted integers, e.g. \"1024\"."
+        },
+
+        "exerciserBenchmark": {
+            "description": "h5bench_exerciser receives its configuration as argv flags; the driver passes them through verbatim.",
+            "type": "object",
+            "properties": {
+                "benchmark":     { "const": "exerciser" },
+                "configuration": { "type": "object" }
+            },
+            "required": ["benchmark"],
+            "additionalProperties": false
+        },
+
+        "metadataBenchmark": {
+            "description": "h5bench_hdf5_iotest writes its own ini-style config; the driver passes a 'file' name and the configuration block.",
+            "type": "object",
+            "properties": {
+                "benchmark":     { "const": "metadata" },
+                "file":          { "type": "string" },
+                "configuration": { "type": "object" }
+            },
+            "required": ["benchmark", "configuration"],
+            "additionalProperties": false
+        },
+
+        "opaqueBenchmark": {
+            "description": "amrex / openpmd / e3sm / macsio — externally-owned benchmark binaries that parse their own configuration; the schema does not introspect their keys.",
+            "type": "object",
+            "properties": {
+                "benchmark":     { "enum": ["amrex", "openpmd", "e3sm", "macsio"] },
+                "file":          { "type": "string" },
+                "configuration": { "type": "object" }
+            },
+            "required": ["benchmark", "configuration"],
+            "additionalProperties": false
+        }
+    }
+}

--- a/src/h5bench.py
+++ b/src/h5bench.py
@@ -158,20 +158,71 @@ class H5bench:
             self.logger.info('Lustre support not detected')
 
     def validate_json(self, setup):
-        """Make sure JSON contains all the necessary properties."""
-        properties = [
-            'mpi',
-            'vol',
-            'file-system',
-            'directory',
-            'benchmarks'
-        ]
+        """Validate the JSON configuration against the bundled JSON schema.
 
-        for p in properties:
-            if p not in setup:
-                self.logger.critical('JSON configuration file is invalid: "{}" property is missing'.format(p))
+        Uses ``schemas/h5bench-config.schema.json`` (located next to or one
+        level above this script, with an ``H5BENCH_SCHEMA`` env-var override)
+        and the optional ``jsonschema`` package for full type/enum/regex
+        validation. When ``jsonschema`` or the schema file is unavailable,
+        falls back to the legacy five-required-keys check so existing setups
+        keep working without a new pip dependency.
+        """
+        schema, jsonschema_mod = self._load_config_schema()
 
+        if schema is not None and jsonschema_mod is not None:
+            try:
+                jsonschema_mod.validate(setup, schema)
+                return
+            except jsonschema_mod.ValidationError as e:
+                location = '/'.join(str(p) for p in e.absolute_path) or '<root>'
+                self.logger.critical(
+                    'JSON configuration invalid at "%s": %s', location, e.message
+                )
                 sys.exit(os.EX_DATAERR)
+
+        if schema is None or jsonschema_mod is None:
+            self.logger.warning(
+                'jsonschema or schema file unavailable; falling back to a '
+                'minimal top-level key check. Install jsonschema '
+                '(pip install jsonschema) for full validation.'
+            )
+
+        for p in ('mpi', 'vol', 'file-system', 'directory', 'benchmarks'):
+            if p not in setup:
+                self.logger.critical(
+                    'JSON configuration file is invalid: "{}" property is missing'.format(p)
+                )
+                sys.exit(os.EX_DATAERR)
+
+    def _load_config_schema(self):
+        """Locate ``h5bench-config.schema.json`` and the ``jsonschema`` module.
+
+        Returns (schema_dict, jsonschema_module). Either element may be None
+        when the file or the package is missing — callers fall back to the
+        legacy validation in that case.
+        """
+        try:
+            import jsonschema as jsonschema_mod
+        except ImportError:
+            return None, None
+
+        here = os.path.dirname(os.path.abspath(__file__))
+        candidates = []
+        env_path = os.environ.get('H5BENCH_SCHEMA')
+        if env_path:
+            candidates.append(env_path)
+        candidates.extend([
+            os.path.join(here, 'schemas', 'h5bench-config.schema.json'),
+            os.path.join(here, '..', 'schemas', 'h5bench-config.schema.json'),
+            os.path.join(here, '..', 'share', 'h5bench', 'schemas', 'h5bench-config.schema.json'),
+        ])
+
+        for path in candidates:
+            if path and os.path.isfile(path):
+                with open(path) as f:
+                    return json.load(f), jsonschema_mod
+
+        return None, jsonschema_mod
 
     def run(self):
         """Run all the benchmarks/kernels."""

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,14 @@ if(Python3_Interpreter_FOUND)
 		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 	)
 
+	# JSON schema validation tests — pure Python, no benchmark binary needed.
+	# Requires the `jsonschema` pip package (see tests/requirements.txt).
+	add_test(
+		NAME "h5bench-schema"
+		COMMAND Python3::Interpreter -m pytest --verbose --rootdir ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/test_schema.py
+		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+	)
+
 	if(H5BENCH_EXERCISER)
 		add_test(
 			NAME "h5bench-sync-exerciser"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 h5py>=3.0
 numpy>=1.20
+jsonschema>=4.0

--- a/tests/test_driver_unit.py
+++ b/tests/test_driver_unit.py
@@ -50,7 +50,17 @@ _REQUIRED_KEYS = ("mpi", "vol", "file-system", "directory", "benchmarks")
 
 
 def _full_setup():
-    return {k: {} if k != "benchmarks" else [] for k in _REQUIRED_KEYS}
+    """A minimal setup dict that both the legacy top-level-keys check and
+    the JSON schema (`schemas/h5bench-config.schema.json`) accept. The
+    opaque-benchmark branch is the least-restrictive way to satisfy the
+    `benchmarks` oneOf, so we use it here."""
+    return {
+        "mpi": {"command": "mpirun"},
+        "vol": {},
+        "file-system": {},
+        "directory": "storage",
+        "benchmarks": [{"benchmark": "amrex", "configuration": {}}],
+    }
 
 
 def test_validate_json_accepts_all_required_keys(bench):

--- a/tests/test_driver_unit.py
+++ b/tests/test_driver_unit.py
@@ -85,6 +85,55 @@ def test_validate_json_tolerates_extra_keys(bench):
 
 
 # ---------------------------------------------------------------------------
+# _load_config_schema and validate_json's legacy-fallback branches
+# ---------------------------------------------------------------------------
+
+
+def test_load_config_schema_returns_none_when_jsonschema_missing(bench, monkeypatch):
+    # Force `import jsonschema` inside _load_config_schema to raise so
+    # the ImportError branch (and the (None, None) return) is exercised.
+    monkeypatch.setitem(sys.modules, "jsonschema", None)
+    schema, mod = bench._load_config_schema()
+    assert schema is None
+    assert mod is None
+
+
+def test_load_config_schema_returns_none_when_no_file_found(bench, monkeypatch):
+    # jsonschema itself imports fine, but no candidate path exists on disk.
+    monkeypatch.setattr(os.path, "isfile", lambda p: False)
+    schema, mod = bench._load_config_schema()
+    assert schema is None
+    assert mod is not None
+
+
+def test_load_config_schema_honors_env_var(bench, monkeypatch, tmp_path):
+    fake = tmp_path / "custom-schema.json"
+    fake.write_text('{"type": "object"}')
+    monkeypatch.setenv("H5BENCH_SCHEMA", str(fake))
+    schema, mod = bench._load_config_schema()
+    assert schema == {"type": "object"}
+    assert mod is not None
+
+
+def test_validate_json_falls_back_when_schema_unavailable(bench, monkeypatch):
+    # When _load_config_schema returns (None, None), validate_json must
+    # still accept a setup that has all five legacy required keys.
+    monkeypatch.setattr(bench, "_load_config_schema", lambda: (None, None))
+    legacy_setup = {k: {} if k != "benchmarks" else [] for k in _REQUIRED_KEYS}
+    bench.validate_json(legacy_setup)
+
+
+@pytest.mark.parametrize("missing_key", _REQUIRED_KEYS)
+def test_validate_json_fallback_exits_when_key_missing(bench, monkeypatch, missing_key):
+    monkeypatch.setattr(bench, "_load_config_schema", lambda: (None, None))
+    legacy_setup = {k: {} if k != "benchmarks" else [] for k in _REQUIRED_KEYS}
+    del legacy_setup[missing_key]
+    with pytest.raises(SystemExit) as excinfo:
+        bench.validate_json(legacy_setup)
+    assert excinfo.value.code == os.EX_DATAERR
+
+
+# ---------------------------------------------------------------------------
 # prepare_parallel — builds the MPI launch command prefix
 # ---------------------------------------------------------------------------
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""
+JSON schema validation tests for the h5bench configuration file.
+
+Drives ``schemas/h5bench-config.schema.json`` directly with ``jsonschema``
+(no benchmark binary, no MPI). Confirms that every production sample under
+``samples/`` still validates, that each pattern-benchmark enum (``MODE``,
+``MEM_PATTERN``, ``FILE_PATTERN``, ``READ_OPTION``, ``COLLECTIVE_DATA``,
+``COMPRESS``, etc.) rejects garbage, and that the driver's ``validate_json``
+falls back to the legacy five-key check when ``jsonschema`` is unavailable.
+"""
+
+import copy
+import glob
+import json
+import os
+
+import jsonschema
+import pytest
+
+from src import h5bench as _h5bench
+
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+SCHEMA_PATH = os.path.join(REPO_ROOT, 'schemas', 'h5bench-config.schema.json')
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope='module')
+def schema():
+    with open(SCHEMA_PATH) as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def base_pattern_config():
+    """A minimal-but-complete write benchmark config that validates cleanly.
+    Tests deep-copy and mutate this to construct each failure case."""
+    return {
+        'mpi': {
+            'command': 'mpirun',
+            'ranks': '2',
+            'configuration': '-np 2 --oversubscribe',
+        },
+        'vol': {},
+        'file-system': {},
+        'directory': 'storage',
+        'benchmarks': [
+            {
+                'benchmark': 'write',
+                'file': 'out.h5',
+                'configuration': {
+                    'MEM_PATTERN': 'CONTIG',
+                    'FILE_PATTERN': 'CONTIG',
+                    'TIMESTEPS': '1',
+                    'DELAYED_CLOSE_TIMESTEPS': '0',
+                    'COLLECTIVE_DATA': 'YES',
+                    'COLLECTIVE_METADATA': 'YES',
+                    'EMULATED_COMPUTE_TIME_PER_TIMESTEP': '0 s',
+                    'NUM_DIMS': '1',
+                    'DIM_1': '1024',
+                    'DIM_2': '1',
+                    'DIM_3': '1',
+                    'MODE': 'SYNC',
+                },
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def bench(tmp_path, monkeypatch):
+    """A real H5bench instance that we can call validate_json on; mirrors
+    the helper in test_driver_unit.py."""
+    monkeypatch.setenv('SHELL', '/bin/bash')
+    cfg = tmp_path / 'dummy.json'
+    cfg.write_text('{}')
+    monkeypatch.chdir(tmp_path)
+    return _h5bench.H5bench(str(cfg), debug=False)
+
+
+# ---------------------------------------------------------------------------
+# Every shipped sample validates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'sample_path',
+    sorted(glob.glob(os.path.join(REPO_ROOT, 'samples', '*.json'))),
+    ids=lambda p: os.path.basename(p),
+)
+def test_production_sample_validates(schema, sample_path):
+    """Every sample under samples/ has to keep validating cleanly. If a new
+    sample lands and the schema is too tight, this fires first."""
+    with open(sample_path) as f:
+        setup = json.load(f)
+    jsonschema.validate(setup, schema)
+
+
+# ---------------------------------------------------------------------------
+# Top-level required keys
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'key', ['mpi', 'vol', 'file-system', 'directory', 'benchmarks']
+)
+def test_top_level_key_missing_rejected(schema, base_pattern_config, key):
+    setup = copy.deepcopy(base_pattern_config)
+    del setup[key]
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(setup, schema)
+
+
+def test_top_level_extra_key_tolerated(schema, base_pattern_config):
+    # The root has additionalProperties: true so callers can ship extra
+    # documentation keys without tripping validation.
+    setup = copy.deepcopy(base_pattern_config)
+    setup['x-comment'] = 'arbitrary note'
+    jsonschema.validate(setup, schema)
+
+
+# ---------------------------------------------------------------------------
+# mpi.command must be a known launcher
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'launcher', ['mpirun', 'mpiexec', 'srun', 'jsrun', 'runjob']
+)
+def test_mpi_known_launcher_accepted(schema, base_pattern_config, launcher):
+    setup = copy.deepcopy(base_pattern_config)
+    setup['mpi']['command'] = launcher
+    jsonschema.validate(setup, schema)
+
+
+def test_mpi_unknown_launcher_rejected(schema, base_pattern_config):
+    setup = copy.deepcopy(base_pattern_config)
+    setup['mpi']['command'] = 'horovodrun'
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(setup, schema)
+
+
+# ---------------------------------------------------------------------------
+# Benchmark dispatcher enum
+# ---------------------------------------------------------------------------
+
+
+_VALID_BENCHMARKS = [
+    'write', 'write-unlimited', 'overwrite', 'append', 'read',
+    'write_var_normal_dist',
+]
+
+
+@pytest.mark.parametrize('name', _VALID_BENCHMARKS)
+def test_pattern_benchmark_names_accepted(schema, base_pattern_config, name):
+    setup = copy.deepcopy(base_pattern_config)
+    setup['benchmarks'][0]['benchmark'] = name
+    jsonschema.validate(setup, schema)
+
+
+def test_bogus_benchmark_name_rejected(schema, base_pattern_config):
+    setup = copy.deepcopy(base_pattern_config)
+    setup['benchmarks'][0]['benchmark'] = 'BOGUS'
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(setup, schema)
+
+
+def test_legacy_write_normal_dist_name_rejected(schema, base_pattern_config):
+    """The legacy `write_normal_dist` name (without `var_`) is not recognised
+    by the driver dispatcher; the schema must reject it so the typo doesn't
+    get reintroduced (samples/sync-write-1d-contig-contig-normal-dist.json
+    used it historically and silently fell through to 'Unsupported')."""
+    setup = copy.deepcopy(base_pattern_config)
+    setup['benchmarks'][0]['benchmark'] = 'write_normal_dist'
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(setup, schema)
+
+
+# ---------------------------------------------------------------------------
+# Pattern config enums
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('mode', ['SYNC', 'ASYNC', 'LOG'])
+def test_mode_enum_accepted(schema, base_pattern_config, mode):
+    setup = copy.deepcopy(base_pattern_config)
+    setup['benchmarks'][0]['configuration']['MODE'] = mode
+    jsonschema.validate(setup, schema)
+
+
+def test_mode_enum_rejects_garbage(schema, base_pattern_config):
+    setup = copy.deepcopy(base_pattern_config)
+    setup['benchmarks'][0]['configuration']['MODE'] = 'sync'  # case-sensitive
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(setup, schema)
+
+
+@pytest.mark.parametrize('pattern', ['CONTIG', 'INTERLEAVED', 'STRIDED'])
+def test_mem_file_pattern_enum_accepted(schema, base_pattern_config, pattern):
+    setup = copy.deepcopy(base_pattern_config)
+    setup['benchmarks'][0]['configuration']['MEM_PATTERN'] = pattern
+    setup['benchmarks'][0]['configuration']['FILE_PATTERN'] = pattern
+    jsonschema.validate(setup, schema)
+
+
+def test_mem_pattern_rejects_garbage(schema, base_pattern_config):
+    setup = copy.deepcopy(base_pattern_config)
+    setup['benchmarks'][0]['configuration']['MEM_PATTERN'] = 'WACKY'
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(setup, schema)
+
+
+def test_collective_data_rejects_garbage(schema, base_pattern_config):
+    setup = copy.deepcopy(base_pattern_config)
+    setup['benchmarks'][0]['configuration']['COLLECTIVE_DATA'] = 'maybe'
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(setup, schema)
+
+
+# ---------------------------------------------------------------------------
+# Numeric-string discipline
+# ---------------------------------------------------------------------------
+
+
+def test_dim_1_actual_number_rejected(schema, base_pattern_config):
+    """h5bench config uses string-quoted integers historically; an actual
+    JSON number is rejected so config writers don't get silent surprises
+    if h5bench's parser ever tightens up."""
+    setup = copy.deepcopy(base_pattern_config)
+    setup['benchmarks'][0]['configuration']['DIM_1'] = 1024
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(setup, schema)
+
+
+def test_emulated_compute_time_pattern(schema, base_pattern_config):
+    setup = copy.deepcopy(base_pattern_config)
+    # Valid forms accepted by h5bench_util parse_time.
+    for value in ('5 s', '0 s', '10 ms', '2 min', '500 us'):
+        setup['benchmarks'][0]['configuration']['EMULATED_COMPUTE_TIME_PER_TIMESTEP'] = value
+        jsonschema.validate(setup, schema)
+    # Garbage rejected.
+    setup['benchmarks'][0]['configuration']['EMULATED_COMPUTE_TIME_PER_TIMESTEP'] = 'soonish'
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(setup, schema)
+
+
+# ---------------------------------------------------------------------------
+# Non-pattern benchmarks pass through opaquely
+# ---------------------------------------------------------------------------
+
+
+def test_exerciser_opaque_configuration_passes(schema, base_pattern_config):
+    setup = copy.deepcopy(base_pattern_config)
+    setup['benchmarks'][0] = {
+        'benchmark': 'exerciser',
+        'configuration': {
+            'numdims': '2',
+            'minels': '8 8',
+            'nsizes': '3',
+            'arbitrary-future-flag': 'yes',
+        },
+    }
+    jsonschema.validate(setup, schema)
+
+
+def test_amrex_opaque_configuration_passes(schema, base_pattern_config):
+    setup = copy.deepcopy(base_pattern_config)
+    setup['benchmarks'][0] = {
+        'benchmark': 'amrex',
+        'file': 'amrex.h5',
+        'configuration': {
+            'mode': 'MULTIPLE',
+            'ncomp': '6',
+            'something-new': True,
+        },
+    }
+    jsonschema.validate(setup, schema)
+
+
+# ---------------------------------------------------------------------------
+# Driver-level wiring — validate_json calls jsonschema when available
+# and falls back gracefully when it isn't.
+# ---------------------------------------------------------------------------
+
+
+def test_driver_validate_json_rejects_bad_mode(bench, base_pattern_config):
+    setup = copy.deepcopy(base_pattern_config)
+    setup['benchmarks'][0]['configuration']['MODE'] = 'NOPE'
+    with pytest.raises(SystemExit) as excinfo:
+        bench.validate_json(setup)
+    assert excinfo.value.code == os.EX_DATAERR
+
+
+def test_driver_validate_json_accepts_valid_config(bench, base_pattern_config):
+    # Should return cleanly without raising.
+    bench.validate_json(base_pattern_config)
+
+
+def test_driver_falls_back_when_jsonschema_missing(
+    bench, base_pattern_config, monkeypatch
+):
+    """Simulate a runtime where jsonschema isn't installed: the driver
+    must still reject obviously broken configs via the legacy check
+    (missing required top-level key)."""
+    # Force the loader to return (None, None), simulating ImportError.
+    monkeypatch.setattr(
+        bench, '_load_config_schema', lambda: (None, None)
+    )
+    # Valid config still passes — falls through legacy checks.
+    bench.validate_json(base_pattern_config)
+    # Missing required key still rejected.
+    broken = copy.deepcopy(base_pattern_config)
+    del broken['mpi']
+    with pytest.raises(SystemExit) as excinfo:
+        bench.validate_json(broken)
+    assert excinfo.value.code == os.EX_DATAERR

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -15,8 +15,13 @@ import glob
 import json
 import os
 
-import jsonschema
 import pytest
+
+# jsonschema is the one hard dependency of this module. CI installs it from
+# tests/requirements.txt; if it is somehow absent the whole module skips
+# (rather than erroring at collection) so a missing dev dependency degrades
+# gracefully instead of failing the ctest run.
+jsonschema = pytest.importorskip("jsonschema")
 
 from src import h5bench as _h5bench
 


### PR DESCRIPTION
## Summary

Replaces the existing 14-line "is this top-level key present?" check in `validate_json` with a full JSON Schema Draft 2020-12 validation pass that catches benchmark-name typos, enum violations, missing required keys per benchmark, wrong-typed configuration values, and out-of-range numerics.

A config with `MODE: "BOGUS"` or `MEM_PATTERN: "sequential"` used to pass the existing validator and only surface as a runtime "Unsupported benchmark/kernel" log; with this PR it's rejected up-front with a precise error pointing at the offending field.

## What's in the PR

### Schema
- `schemas/h5bench-config.schema.json`: 200 LoC. Covers:
  - **Top level**: `mpi` / `vol` / `file-system` / `directory` / `benchmarks` required; root is `additionalProperties: true` so configs can carry their own documentation keys.
  - **`mpi.command`**: enum of the 5 launchers the driver actually handles (`mpirun` / `mpiexec` / `srun` / `jsrun` / `runjob`).
  - **`benchmarks[].benchmark`**: enum of the 12 names the dispatcher in `h5bench.py:234` actually recognises. This is what catches the long-standing `write_normal_dist` typo; the driver only dispatches on `write_var_normal_dist`, so the legacy name was silently falling through to the "Unsupported benchmark/kernel" branch.
  - **Pattern benchmarks** (`write` / `read` / `overwrite` / `append` / `write-unlimited` / `write_var_normal_dist`) — strictly typed `configuration` with:
    - `MODE` enum `SYNC` / `ASYNC` / `LOG`
    - `MEM_PATTERN` / `FILE_PATTERN` enum `CONTIG` / `INTERLEAVED` / `STRIDED`
    - `READ_OPTION` enum `FULL` / `PARTIAL` / `STRIDED` / `LDC` / `RDC` / `CS` / `PRL`
    - `COLLECTIVE_DATA` / `COLLECTIVE_METADATA` / `COMPRESS` / `ALIGN` enum `YES` / `NO`
    - `NUM_DIMS` enum `1` / `2` / `3`
    - `DIM_*` / `CHUNK_DIM_*` / `STRIDE_*` / `BLOCK_*` / `ALIGN_*` / `TIMESTEPS` / `DELAYED_CLOSE_TIMESTEPS` / `STDEV_DIM_1` as numeric strings (`^\\\d+\$`)
    - `NUM_PARTICLES` as `<n>` or `<n> Ks`/`Ms`/`Gs`/`Ts` (matches h5bench's `parse_unit`)
    - `EMULATED_COMPUTE_TIME_PER_TIMESTEP` as `<n> <unit>` with unit ∈ `min` / `sec` / `s` / `ms` / `us`
    - `additionalProperties: false` — unknown keys are rejected
  - **Other benchmarks** (`exerciser` / `metadata` / `amrex` / `openpmd` / `e3sm` / `macsio`): opaque `configuration` object (`additionalProperties: true`) since the binary parses its own keys.

### Driver wiring
- `src/h5bench.py`: `validate_json` is now a soft-import of `jsonschema`:
  - If installed, validates against the bundled schema. On failure, logs the JSON path of the offending field (`benchmarks/0/configuration/MODE`) and exits `EX_DATAERR`.
  - If missing, logs a one-line "install jsonschema for full validation" warning and falls back to the legacy 5-required-keys check. **No hard new runtime dependency.**
- Schema lookup tries `\$H5BENCH_SCHEMA` first, then relative paths covering source-tree, build-dir, and install layouts: `<dir>/schemas/`, `<dir>/../schemas/`, `<dir>/../share/h5bench/schemas/`.

### Sample fix (drive-by)
- `samples/sync-write-1d-contig-contig-normal-dist.json`: `"benchmark": "write_normal_dist"` → `"write_var_normal_dist"`. The driver only recognises the `var_` form (see `h5bench.py:234`); the sample was the schema-validation pass's first real catch.

### Tests
- `tests/test_schema.py` — 87 tests covering:
  - **Every shipped sample** under `samples/` validates cleanly (51 parametrized cases).
  - Each top-level required key removed in turn → `ValidationError`.
  - Each pattern enum: valid values accepted, one garbage value rejected per enum.
  - Legacy `write_normal_dist` benchmark name rejected (locks the bug fix in).
  - `DIM_1` as a JSON number (rather than string) rejected.
  - `EMULATED_COMPUTE_TIME_PER_TIMESTEP` pattern accepts `5 s` / `0 s` / `10 ms` / `2 min` / `500 us` and rejects `"soonish"`.
  - Opaque benchmarks (exerciser, amrex) accept arbitrary configuration keys.
  - Driver-level: `validate_json` exits `EX_DATAERR` on schema failure, accepts a valid config, and (with `jsonschema` patched away) still rejects configs missing required top-level keys via the legacy fallback.
- `tests/CMakeLists.txt` registers `h5bench-schema` with ctest.
- `tests/requirements.txt` pins `jsonschema>=4.0`.

### Docs
- `docs/source/running.rst` adds a short paragraph pointing at `schemas/h5bench-config.schema.json` plus a one-liner Python invocation for out-of-band config validation.

## Local verification

- `pytest tests/test_schema.py` → **87/87 pass in 1.22s**.
- Schema validates every existing `samples/*.json` after the one typo fix.
- `validate_json` rejects `MODE: "NOPE"` with `EX_DATAERR`; valid configs pass through.
- With `jsonschema` monkey-patched away, missing-top-level-key configs still rejected via legacy path.

## Test plan
- [x] CI matrix passes (legacy validation path unchanged for installs without `jsonschema`).
- [x] Coverage workflow picks up `tests/test_schema.py` automatically (ctest entry added).
- [x] Spot-check on a fresh checkout that `pip install jsonschema && ./h5bench bogus.json` reports a usable error like: `h5bench - CRITICAL - JSON configuration invalid at "benchmarks/0/configuration/MODE": 'BOGUS' is not one of ['SYNC', 'ASYNC', 'LOG']`