### PR TITLE
Extend fail-fast checks for malloc and HDF5 to remaining pattern binaries

### DIFF
--- a/h5bench_patterns/h5bench_append.c
+++ b/h5bench_patterns/h5bench_append.c
@@ -75,28 +75,28 @@ append_h5_data(bench_params params, time_step *ts, hid_t loc, hid_t *dset_ids, h
     float *data_1D_FLOAT, **data_2D_FLOAT, ***data_3D_FLOAT;
 
     if (params.num_dims == 1) {
-        data_1D_INT   = malloc(params.dim_1 * sizeof(int));
-        data_1D_FLOAT = malloc(params.dim_1 * sizeof(float));
+        H5B_MALLOC(data_1D_INT, params.dim_1 * sizeof(int));
+        H5B_MALLOC(data_1D_FLOAT, params.dim_1 * sizeof(float));
     }
 
     if (params.num_dims == 2) {
-        data_2D_INT   = malloc(params.dim_1 * sizeof(int *));
-        data_2D_FLOAT = malloc(params.dim_1 * sizeof(float *));
+        H5B_MALLOC(data_2D_INT, params.dim_1 * sizeof(int *));
+        H5B_MALLOC(data_2D_FLOAT, params.dim_1 * sizeof(float *));
         for (int i = 0; i < params.dim_1; i++) {
-            data_2D_INT[i]   = malloc(params.dim_2 * sizeof(int));
-            data_2D_FLOAT[i] = malloc(params.dim_2 * sizeof(float));
+            H5B_MALLOC(data_2D_INT[i], params.dim_2 * sizeof(int));
+            H5B_MALLOC(data_2D_FLOAT[i], params.dim_2 * sizeof(float));
         }
     }
 
     if (params.num_dims == 3) {
-        data_3D_INT   = malloc(params.dim_1 * sizeof(int **));
-        data_3D_FLOAT = malloc(params.dim_1 * sizeof(float **));
+        H5B_MALLOC(data_3D_INT, params.dim_1 * sizeof(int **));
+        H5B_MALLOC(data_3D_FLOAT, params.dim_1 * sizeof(float **));
         for (int i = 0; i < params.dim_1; i++) {
-            data_3D_INT[i]   = malloc(params.dim_2 * sizeof(int *));
-            data_3D_FLOAT[i] = malloc(params.dim_2 * sizeof(float *));
+            H5B_MALLOC(data_3D_INT[i], params.dim_2 * sizeof(int *));
+            H5B_MALLOC(data_3D_FLOAT[i], params.dim_2 * sizeof(float *));
             for (int j = 0; j < params.dim_2; j++) {
-                data_3D_INT[i][j]   = malloc(params.dim_3 * sizeof(int));
-                data_3D_FLOAT[i][j] = malloc(params.dim_3 * sizeof(float));
+                H5B_MALLOC(data_3D_INT[i][j], params.dim_3 * sizeof(int));
+                H5B_MALLOC(data_3D_FLOAT[i][j], params.dim_3 * sizeof(float));
             }
         }
     }
@@ -152,13 +152,21 @@ append_h5_data(bench_params params, time_step *ts, hid_t loc, hid_t *dset_ids, h
     t1 = get_time_usec();
 
     dset_ids[0] = H5Dopen_async(loc, "x", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[0], "H5Dopen_async(x)");
     dset_ids[1] = H5Dopen_async(loc, "y", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[1], "H5Dopen_async(y)");
     dset_ids[2] = H5Dopen_async(loc, "z", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[2], "H5Dopen_async(z)");
     dset_ids[3] = H5Dopen_async(loc, "id_1", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[3], "H5Dopen_async(id_1)");
     dset_ids[4] = H5Dopen_async(loc, "id_2", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[4], "H5Dopen_async(id_2)");
     dset_ids[5] = H5Dopen_async(loc, "px", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[5], "H5Dopen_async(px)");
     dset_ids[6] = H5Dopen_async(loc, "py", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[6], "H5Dopen_async(py)");
     dset_ids[7] = H5Dopen_async(loc, "pz", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[7], "H5Dopen_async(pz)");
 
     t2 = get_time_usec();
 
@@ -350,11 +358,14 @@ _set_dataspace_seq_3D(hid_t *filespace_in_out, hid_t *memspace_out, unsigned lon
 hid_t
 get_filespace(hid_t file_id)
 {
-    char *grp_name  = "/Timestep_0";
-    char *ds_name   = "px";
-    hid_t gid       = H5Gopen2(file_id, grp_name, H5P_DEFAULT);
-    hid_t dsid      = H5Dopen2(gid, ds_name, H5P_DEFAULT);
+    char *grp_name = "/Timestep_0";
+    char *ds_name  = "px";
+    hid_t gid      = H5Gopen2(file_id, grp_name, H5P_DEFAULT);
+    H5B_CHECK_HID(gid, "H5Gopen2(/Timestep_0)");
+    hid_t dsid = H5Dopen2(gid, ds_name, H5P_DEFAULT);
+    H5B_CHECK_HID(dsid, "H5Dopen2(px)");
     hid_t filespace = H5Dget_space(dsid);
+    H5B_CHECK_HID(filespace, "H5Dget_space");
     H5Dclose(dsid);
     H5Gclose(gid);
     return filespace;
@@ -426,8 +437,8 @@ _run_benchmark_modify(hid_t file_id, hid_t fapl, hid_t gapl, hid_t filespace, be
         meta_time1 = 0, meta_time2 = 0, meta_time3 = 0, meta_time4 = 0, meta_time5 = 0;
         snprintf(grp_name, sizeof(grp_name), "Timestep_%d", ts_index);
         time_step *ts = &(MEM_MONITOR->time_steps[ts_index]);
-        MEM_MONITOR->mem_used += ts->mem_size;
         assert(ts);
+        MEM_MONITOR->mem_used += ts->mem_size;
 
         if (params.cnt_time_step_delay > 0) {
             if (ts_index > params.cnt_time_step_delay - 1) // delayed close on all ids of the previous ts
@@ -437,6 +448,7 @@ _run_benchmark_modify(hid_t file_id, hid_t fapl, hid_t gapl, hid_t filespace, be
 
         t1         = get_time_usec();
         ts->grp_id = H5Gopen_async(file_id, grp_name, gapl, ts->es_meta_create);
+        H5B_CHECK_HID(ts->grp_id, "H5Gopen_async");
         t2         = get_time_usec();
         meta_time3 = (t2 - t1);
 
@@ -504,7 +516,13 @@ main(int argc, char *argv[])
 {
     int mpi_thread_lvl_provided = -1;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_thread_lvl_provided);
-    assert(MPI_THREAD_MULTIPLE == mpi_thread_lvl_provided);
+    if (mpi_thread_lvl_provided != MPI_THREAD_MULTIPLE) {
+        fprintf(stderr,
+                "h5bench_append: MPI implementation does not provide MPI_THREAD_MULTIPLE "
+                "(got level %d)\n",
+                mpi_thread_lvl_provided);
+        h5bench_die(NULL);
+    }
     MPI_Comm_rank(MPI_COMM_WORLD, &MY_RANK);
     MPI_Comm_size(MPI_COMM_WORLD, &NUM_RANKS);
 
@@ -545,7 +563,8 @@ main(int argc, char *argv[])
 
     hsize_t dims[64] = {0};
 
-    hid_t         file_id         = H5Fopen(file_name, H5F_ACC_RDWR, fapl);
+    hid_t file_id = H5Fopen(file_name, H5F_ACC_RDWR, fapl);
+    H5B_CHECK_HID(file_id, "H5Fopen");
     hid_t         filespace       = get_filespace(file_id);
     int           dims_cnt        = H5Sget_simple_extent_dims(filespace, dims, NULL);
     unsigned long total_particles = 1;

--- a/h5bench_patterns/h5bench_overwrite.c
+++ b/h5bench_patterns/h5bench_overwrite.c
@@ -71,28 +71,28 @@ overwrite_h5_data(bench_params params, time_step *ts, hid_t loc, hid_t *dset_ids
     float *data_1D_FLOAT, **data_2D_FLOAT, ***data_3D_FLOAT;
 
     if (params.num_dims == 1) {
-        data_1D_INT   = malloc(params.dim_1 * sizeof(int));
-        data_1D_FLOAT = malloc(params.dim_1 * sizeof(float));
+        H5B_MALLOC(data_1D_INT, params.dim_1 * sizeof(int));
+        H5B_MALLOC(data_1D_FLOAT, params.dim_1 * sizeof(float));
     }
 
     if (params.num_dims == 2) {
-        data_2D_INT   = malloc(params.dim_1 * sizeof(int *));
-        data_2D_FLOAT = malloc(params.dim_1 * sizeof(float *));
+        H5B_MALLOC(data_2D_INT, params.dim_1 * sizeof(int *));
+        H5B_MALLOC(data_2D_FLOAT, params.dim_1 * sizeof(float *));
         for (int i = 0; i < params.dim_1; i++) {
-            data_2D_INT[i]   = malloc(params.dim_2 * sizeof(int));
-            data_2D_FLOAT[i] = malloc(params.dim_2 * sizeof(float));
+            H5B_MALLOC(data_2D_INT[i], params.dim_2 * sizeof(int));
+            H5B_MALLOC(data_2D_FLOAT[i], params.dim_2 * sizeof(float));
         }
     }
 
     if (params.num_dims == 3) {
-        data_3D_INT   = malloc(params.dim_1 * sizeof(int **));
-        data_3D_FLOAT = malloc(params.dim_1 * sizeof(float **));
+        H5B_MALLOC(data_3D_INT, params.dim_1 * sizeof(int **));
+        H5B_MALLOC(data_3D_FLOAT, params.dim_1 * sizeof(float **));
         for (int i = 0; i < params.dim_1; i++) {
-            data_3D_INT[i]   = malloc(params.dim_2 * sizeof(int *));
-            data_3D_FLOAT[i] = malloc(params.dim_2 * sizeof(float *));
+            H5B_MALLOC(data_3D_INT[i], params.dim_2 * sizeof(int *));
+            H5B_MALLOC(data_3D_FLOAT[i], params.dim_2 * sizeof(float *));
             for (int j = 0; j < params.dim_2; j++) {
-                data_3D_INT[i][j]   = malloc(params.dim_3 * sizeof(int));
-                data_3D_FLOAT[i][j] = malloc(params.dim_3 * sizeof(float));
+                H5B_MALLOC(data_3D_INT[i][j], params.dim_3 * sizeof(int));
+                H5B_MALLOC(data_3D_FLOAT[i][j], params.dim_3 * sizeof(float));
             }
         }
     }
@@ -142,13 +142,21 @@ overwrite_h5_data(bench_params params, time_step *ts, hid_t loc, hid_t *dset_ids
     t1 = get_time_usec();
 
     dset_ids[0] = H5Dopen_async(loc, "x", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[0], "H5Dopen_async(x)");
     dset_ids[1] = H5Dopen_async(loc, "y", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[1], "H5Dopen_async(y)");
     dset_ids[2] = H5Dopen_async(loc, "z", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[2], "H5Dopen_async(z)");
     dset_ids[3] = H5Dopen_async(loc, "id_1", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[3], "H5Dopen_async(id_1)");
     dset_ids[4] = H5Dopen_async(loc, "id_2", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[4], "H5Dopen_async(id_2)");
     dset_ids[5] = H5Dopen_async(loc, "px", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[5], "H5Dopen_async(px)");
     dset_ids[6] = H5Dopen_async(loc, "py", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[6], "H5Dopen_async(py)");
     dset_ids[7] = H5Dopen_async(loc, "pz", dapl, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[7], "H5Dopen_async(pz)");
 
     t2 = get_time_usec();
 
@@ -326,11 +334,14 @@ _set_dataspace_seq_3D(hid_t *filespace_in_out, hid_t *memspace_out, unsigned lon
 hid_t
 get_filespace(hid_t file_id)
 {
-    char *grp_name  = "/Timestep_0";
-    char *ds_name   = "px";
-    hid_t gid       = H5Gopen2(file_id, grp_name, H5P_DEFAULT);
-    hid_t dsid      = H5Dopen2(gid, ds_name, H5P_DEFAULT);
+    char *grp_name = "/Timestep_0";
+    char *ds_name  = "px";
+    hid_t gid      = H5Gopen2(file_id, grp_name, H5P_DEFAULT);
+    H5B_CHECK_HID(gid, "H5Gopen2(/Timestep_0)");
+    hid_t dsid = H5Dopen2(gid, ds_name, H5P_DEFAULT);
+    H5B_CHECK_HID(dsid, "H5Dopen2(px)");
     hid_t filespace = H5Dget_space(dsid);
+    H5B_CHECK_HID(filespace, "H5Dget_space");
     H5Dclose(dsid);
     H5Gclose(gid);
     return filespace;
@@ -402,8 +413,8 @@ _run_benchmark_modify(hid_t file_id, hid_t fapl, hid_t gapl, hid_t filespace, be
         meta_time1 = 0, meta_time2 = 0, meta_time3 = 0, meta_time4 = 0, meta_time5 = 0;
         snprintf(grp_name, sizeof(grp_name), "Timestep_%d", ts_index);
         time_step *ts = &(MEM_MONITOR->time_steps[ts_index]);
-        MEM_MONITOR->mem_used += ts->mem_size;
         assert(ts);
+        MEM_MONITOR->mem_used += ts->mem_size;
 
         if (params.cnt_time_step_delay > 0) {
             if (ts_index > params.cnt_time_step_delay - 1) // delayed close on all ids of the previous ts
@@ -413,6 +424,7 @@ _run_benchmark_modify(hid_t file_id, hid_t fapl, hid_t gapl, hid_t filespace, be
 
         t1         = get_time_usec();
         ts->grp_id = H5Gopen_async(file_id, grp_name, gapl, ts->es_meta_create);
+        H5B_CHECK_HID(ts->grp_id, "H5Gopen_async");
         t2         = get_time_usec();
         meta_time3 = (t2 - t1);
 
@@ -480,7 +492,13 @@ main(int argc, char *argv[])
 {
     int mpi_thread_lvl_provided = -1;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_thread_lvl_provided);
-    assert(MPI_THREAD_MULTIPLE == mpi_thread_lvl_provided);
+    if (mpi_thread_lvl_provided != MPI_THREAD_MULTIPLE) {
+        fprintf(stderr,
+                "h5bench_overwrite: MPI implementation does not provide MPI_THREAD_MULTIPLE "
+                "(got level %d)\n",
+                mpi_thread_lvl_provided);
+        h5bench_die(NULL);
+    }
     MPI_Comm_rank(MPI_COMM_WORLD, &MY_RANK);
     MPI_Comm_size(MPI_COMM_WORLD, &NUM_RANKS);
 
@@ -521,7 +539,8 @@ main(int argc, char *argv[])
 
     hsize_t dims[64] = {0};
 
-    hid_t         file_id         = H5Fopen(file_name, H5F_ACC_RDWR, fapl);
+    hid_t file_id = H5Fopen(file_name, H5F_ACC_RDWR, fapl);
+    H5B_CHECK_HID(file_id, "H5Fopen");
     hid_t         filespace       = get_filespace(file_id);
     int           dims_cnt        = H5Sget_simple_extent_dims(filespace, dims, NULL);
     unsigned long total_particles = 1;

--- a/h5bench_patterns/h5bench_write_normal_dist.c
+++ b/h5bench_patterns/h5bench_write_normal_dist.c
@@ -198,7 +198,8 @@ make_compound_type_separates()
 particle *
 prepare_data_interleaved(long particle_cnt, unsigned long *data_size_out)
 {
-    particle *data_out = (particle *)malloc(particle_cnt * sizeof(particle));
+    particle *data_out;
+    H5B_MALLOC(data_out, particle_cnt * sizeof(particle));
 
     for (long i = 0; i < particle_cnt; i++) {
         data_out[i].id_1 = i;
@@ -217,17 +218,18 @@ prepare_data_interleaved(long particle_cnt, unsigned long *data_size_out)
 data_contig_md *
 prepare_data_contig_1D(unsigned long long particle_cnt, unsigned long *data_size_out)
 {
-    data_contig_md *data_out = (data_contig_md *)malloc(sizeof(data_contig_md));
-    data_out->particle_cnt   = particle_cnt;
+    data_contig_md *data_out;
+    H5B_MALLOC(data_out, sizeof(data_contig_md));
+    data_out->particle_cnt = particle_cnt;
 
-    data_out->x     = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->y     = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->z     = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->px    = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->py    = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->pz    = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->id_1  = (int *)malloc(particle_cnt * sizeof(int));
-    data_out->id_2  = (float *)malloc(particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->x, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->y, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->z, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->px, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->py, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->pz, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->id_1, particle_cnt * sizeof(int));
+    H5B_MALLOC(data_out->id_2, particle_cnt * sizeof(float));
     data_out->dim_1 = particle_cnt;
     data_out->dim_2 = 1;
     data_out->dim_3 = 1;
@@ -258,20 +260,21 @@ prepare_data_contig_2D(unsigned long long particle_cnt, long dim_1, long dim_2, 
         return NULL;
     }
     assert(particle_cnt == dim_1 * dim_2);
-    data_contig_md *data_out = (data_contig_md *)malloc(sizeof(data_contig_md));
-    data_out->particle_cnt   = particle_cnt;
-    data_out->dim_1          = dim_1;
-    data_out->dim_2          = dim_2;
-    data_out->dim_3          = 1;
+    data_contig_md *data_out;
+    H5B_MALLOC(data_out, sizeof(data_contig_md));
+    data_out->particle_cnt = particle_cnt;
+    data_out->dim_1        = dim_1;
+    data_out->dim_2        = dim_2;
+    data_out->dim_3        = 1;
 
-    data_out->x    = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->y    = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->z    = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->px   = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->py   = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->pz   = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->id_1 = (int *)malloc(particle_cnt * sizeof(int));
-    data_out->id_2 = (float *)malloc(particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->x, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->y, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->z, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->px, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->py, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->pz, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->id_1, particle_cnt * sizeof(int));
+    H5B_MALLOC(data_out->id_2, particle_cnt * sizeof(float));
 
     long idx = 0;
     for (long i1 = 0; i1 < dim_1; i1++) {
@@ -305,20 +308,21 @@ prepare_data_contig_3D(unsigned long long particle_cnt, long dim_1, long dim_2, 
     }
 
     assert(particle_cnt == dim_1 * dim_2 * dim_3);
-    data_contig_md *data_out = (data_contig_md *)malloc(sizeof(data_contig_md));
-    data_out->particle_cnt   = particle_cnt;
-    data_out->dim_1          = dim_1;
-    data_out->dim_2          = dim_2;
-    data_out->dim_3          = dim_3;
-    data_out->x              = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->y              = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->z              = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->px             = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->py             = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->pz             = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->id_1           = (int *)malloc(particle_cnt * sizeof(int));
-    data_out->id_2           = (float *)malloc(particle_cnt * sizeof(float));
-    long idx                 = 0;
+    data_contig_md *data_out;
+    H5B_MALLOC(data_out, sizeof(data_contig_md));
+    data_out->particle_cnt = particle_cnt;
+    data_out->dim_1        = dim_1;
+    data_out->dim_2        = dim_2;
+    data_out->dim_3        = dim_3;
+    H5B_MALLOC(data_out->x, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->y, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->z, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->px, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->py, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->pz, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->id_1, particle_cnt * sizeof(int));
+    H5B_MALLOC(data_out->id_2, particle_cnt * sizeof(float));
+    long idx = 0;
     for (long i1 = 0; i1 < dim_1; i1++) {
         for (long i2 = 0; i2 < dim_2; i2++) {
             for (long i3 = 0; i3 < dim_3; i3++) {
@@ -496,20 +500,28 @@ data_write_contig_contig_MD_array(time_step *ts, hid_t loc, hid_t *dset_ids, hid
 
     dset_ids[0] = H5Dcreate_async(loc, "x", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[0], "H5Dcreate_async(x)");
     dset_ids[1] = H5Dcreate_async(loc, "y", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[1], "H5Dcreate_async(y)");
     dset_ids[2] = H5Dcreate_async(loc, "z", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[2], "H5Dcreate_async(z)");
     dset_ids[3] = H5Dcreate_async(loc, "px", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[3], "H5Dcreate_async(px)");
     dset_ids[4] = H5Dcreate_async(loc, "py", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[4], "H5Dcreate_async(py)");
     dset_ids[5] = H5Dcreate_async(loc, "pz", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[5], "H5Dcreate_async(pz)");
     dset_ids[6] = H5Dcreate_async(loc, "id_1", H5T_NATIVE_INT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[6], "H5Dcreate_async(id_1)");
     dset_ids[7] = H5Dcreate_async(loc, "id_2", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[7], "H5Dcreate_async(id_2)");
 
     unsigned t2 = get_time_usec();
 
@@ -554,6 +566,7 @@ data_write_contig_to_interleaved(time_step *ts, hid_t loc, hid_t *dset_ids, hid_
     unsigned t1 = get_time_usec();
     dset_ids[0] = H5Dcreate_async(loc, "particles", PARTICLE_COMPOUND_TYPE, filespace, H5P_DEFAULT, dcpl,
                                   H5P_DEFAULT, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[0], "H5Dcreate_async(particles)");
 
     unsigned t2 = get_time_usec();
     ierr = H5Dwrite_async(dset_ids[0], PARTICLE_COMPOUND_TYPE_SEPARATES[0], memspace, filespace, plist_id,
@@ -595,20 +608,28 @@ data_write_interleaved_to_contig(time_step *ts, hid_t loc, hid_t *dset_ids, hid_
     unsigned t1 = get_time_usec();
     dset_ids[0] = H5Dcreate_async(loc, "x", PARTICLE_COMPOUND_TYPE_SEPARATES[0], filespace, H5P_DEFAULT, dcpl,
                                   H5P_DEFAULT, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[0], "H5Dcreate_async(x)");
     dset_ids[1] = H5Dcreate_async(loc, "y", PARTICLE_COMPOUND_TYPE_SEPARATES[1], filespace, H5P_DEFAULT, dcpl,
                                   H5P_DEFAULT, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[1], "H5Dcreate_async(y)");
     dset_ids[2] = H5Dcreate_async(loc, "z", PARTICLE_COMPOUND_TYPE_SEPARATES[2], filespace, H5P_DEFAULT, dcpl,
                                   H5P_DEFAULT, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[2], "H5Dcreate_async(z)");
     dset_ids[3] = H5Dcreate_async(loc, "px", PARTICLE_COMPOUND_TYPE_SEPARATES[3], filespace, H5P_DEFAULT,
                                   dcpl, H5P_DEFAULT, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[3], "H5Dcreate_async(px)");
     dset_ids[4] = H5Dcreate_async(loc, "py", PARTICLE_COMPOUND_TYPE_SEPARATES[4], filespace, H5P_DEFAULT,
                                   dcpl, H5P_DEFAULT, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[4], "H5Dcreate_async(py)");
     dset_ids[5] = H5Dcreate_async(loc, "pz", PARTICLE_COMPOUND_TYPE_SEPARATES[5], filespace, H5P_DEFAULT,
                                   dcpl, H5P_DEFAULT, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[5], "H5Dcreate_async(pz)");
     dset_ids[6] = H5Dcreate_async(loc, "id_1", PARTICLE_COMPOUND_TYPE_SEPARATES[6], filespace, H5P_DEFAULT,
                                   dcpl, H5P_DEFAULT, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[6], "H5Dcreate_async(id_1)");
     dset_ids[7] = H5Dcreate_async(loc, "id_2", PARTICLE_COMPOUND_TYPE_SEPARATES[7], filespace, H5P_DEFAULT,
                                   dcpl, H5P_DEFAULT, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[7], "H5Dcreate_async(id_2)");
 
     unsigned t2 = get_time_usec();
 
@@ -650,6 +671,7 @@ data_write_interleaved_to_interleaved(time_step *ts, hid_t loc, hid_t *dset_ids,
     unsigned t1 = get_time_usec();
     dset_ids[0] = H5Dcreate_async(loc, "particles", PARTICLE_COMPOUND_TYPE, filespace, H5P_DEFAULT, dcpl,
                                   H5P_DEFAULT, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[0], "H5Dcreate_async(particles)");
 
     unsigned t2 = get_time_usec();
     ierr        = H5Dwrite_async(dset_ids[0], PARTICLE_COMPOUND_TYPE, memspace, filespace, plist_id, data_in,
@@ -797,10 +819,10 @@ _run_benchmark_write(bench_params params, hid_t file_id, hid_t fapl, hid_t files
     for (int ts_index = 0; ts_index < timestep_cnt; ts_index++) {
         meta_time1 = 0, meta_time2 = 0, meta_time3 = 0, meta_time4 = 0, meta_time5 = 0;
         time_step *ts = &(MEM_MONITOR->time_steps[ts_index]);
+        assert(ts);
         MEM_MONITOR->mem_used += ts->mem_size;
         //        print_mem_bound(MEM_MONITOR);
         snprintf(grp_name, sizeof(grp_name), "Timestep_%d", ts_index);
-        assert(ts);
 
         if (params.cnt_time_step_delay > 0) {
             if (ts_index > params.cnt_time_step_delay - 1) // delayed close on all ids of the previous ts
@@ -812,6 +834,7 @@ _run_benchmark_write(bench_params params, hid_t file_id, hid_t fapl, hid_t files
         t0 = get_time_usec();
         ts->grp_id =
             H5Gcreate_async(file_id, grp_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT, ts->es_meta_create);
+        H5B_CHECK_HID(ts->grp_id, "H5Gcreate_async");
 
         t1         = get_time_usec();
         meta_time3 = (t1 - t0);
@@ -1014,7 +1037,13 @@ main(int argc, char *argv[])
 {
     int mpi_thread_lvl_provided = -1;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_thread_lvl_provided);
-    assert(MPI_THREAD_MULTIPLE == mpi_thread_lvl_provided);
+    if (mpi_thread_lvl_provided != MPI_THREAD_MULTIPLE) {
+        fprintf(stderr,
+                "h5bench_write_var_normal_dist: MPI implementation does not provide MPI_THREAD_MULTIPLE "
+                "(got level %d)\n",
+                mpi_thread_lvl_provided);
+        h5bench_die(NULL);
+    }
     MPI_Comm_rank(MPI_COMM_WORLD, &MY_RANK);
     MPI_Comm_size(MPI_COMM_WORLD, &NUM_RANKS);
     MPI_Comm           comm    = MPI_COMM_WORLD;
@@ -1080,7 +1109,7 @@ main(int argc, char *argv[])
 
     STDEV_DIM_1 = params.stdev_dim_1;
 
-    holder = (long long *)malloc(NUM_RANKS * sizeof(long long));
+    H5B_MALLOC(holder, NUM_RANKS * sizeof(long long));
 
     if (MY_RANK == 0) {
         printf("Start benchmark: h5bench_write\n");
@@ -1143,9 +1172,11 @@ main(int argc, char *argv[])
                  get_dir_from_path(output_file), MY_RANK, get_file_name_from_path(output_file));
 
         file_id = H5Fcreate_async(mpi_rank_output_file_path, H5F_ACC_TRUNC, H5P_DEFAULT, fapl, 0);
+        H5B_CHECK_HID(file_id, "H5Fcreate_async");
     }
     else {
         file_id = H5Fcreate_async(output_file, H5F_ACC_TRUNC, H5P_DEFAULT, fapl, 0);
+        H5B_CHECK_HID(file_id, "H5Fcreate_async");
     }
     unsigned long tfopen_end = get_time_usec();
 

--- a/h5bench_patterns/h5bench_write_unlimited.c
+++ b/h5bench_patterns/h5bench_write_unlimited.c
@@ -130,7 +130,8 @@ make_compound_type_separates()
 particle *
 prepare_data_interleaved(long particle_cnt, unsigned long *data_size_out)
 {
-    particle *data_out = (particle *)malloc(particle_cnt * sizeof(particle));
+    particle *data_out;
+    H5B_MALLOC(data_out, particle_cnt * sizeof(particle));
 
     for (long i = 0; i < particle_cnt; i++) {
         data_out[i].id_1 = i;
@@ -149,17 +150,18 @@ prepare_data_interleaved(long particle_cnt, unsigned long *data_size_out)
 data_contig_md *
 prepare_data_contig_1D(unsigned long long particle_cnt, unsigned long *data_size_out)
 {
-    data_contig_md *data_out = (data_contig_md *)malloc(sizeof(data_contig_md));
-    data_out->particle_cnt   = particle_cnt;
+    data_contig_md *data_out;
+    H5B_MALLOC(data_out, sizeof(data_contig_md));
+    data_out->particle_cnt = particle_cnt;
 
-    data_out->x     = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->y     = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->z     = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->px    = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->py    = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->pz    = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->id_1  = (int *)malloc(particle_cnt * sizeof(int));
-    data_out->id_2  = (float *)malloc(particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->x, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->y, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->z, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->px, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->py, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->pz, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->id_1, particle_cnt * sizeof(int));
+    H5B_MALLOC(data_out->id_2, particle_cnt * sizeof(float));
     data_out->dim_1 = particle_cnt;
     data_out->dim_2 = 1;
     data_out->dim_3 = 1;
@@ -190,20 +192,21 @@ prepare_data_contig_2D(unsigned long long particle_cnt, long dim_1, long dim_2, 
         return NULL;
     }
     assert(particle_cnt == dim_1 * dim_2);
-    data_contig_md *data_out = (data_contig_md *)malloc(sizeof(data_contig_md));
-    data_out->particle_cnt   = particle_cnt;
-    data_out->dim_1          = dim_1;
-    data_out->dim_2          = dim_2;
-    data_out->dim_3          = 1;
+    data_contig_md *data_out;
+    H5B_MALLOC(data_out, sizeof(data_contig_md));
+    data_out->particle_cnt = particle_cnt;
+    data_out->dim_1        = dim_1;
+    data_out->dim_2        = dim_2;
+    data_out->dim_3        = 1;
 
-    data_out->x    = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->y    = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->z    = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->px   = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->py   = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->pz   = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->id_1 = (int *)malloc(particle_cnt * sizeof(int));
-    data_out->id_2 = (float *)malloc(particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->x, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->y, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->z, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->px, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->py, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->pz, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->id_1, particle_cnt * sizeof(int));
+    H5B_MALLOC(data_out->id_2, particle_cnt * sizeof(float));
 
     long idx = 0;
     for (long i1 = 0; i1 < dim_1; i1++) {
@@ -237,20 +240,21 @@ prepare_data_contig_3D(unsigned long long particle_cnt, long dim_1, long dim_2, 
     }
 
     assert(particle_cnt == dim_1 * dim_2 * dim_3);
-    data_contig_md *data_out = (data_contig_md *)malloc(sizeof(data_contig_md));
-    data_out->particle_cnt   = particle_cnt;
-    data_out->dim_1          = dim_1;
-    data_out->dim_2          = dim_2;
-    data_out->dim_3          = dim_3;
-    data_out->x              = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->y              = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->z              = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->px             = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->py             = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->pz             = (float *)malloc(particle_cnt * sizeof(float));
-    data_out->id_1           = (int *)malloc(particle_cnt * sizeof(int));
-    data_out->id_2           = (float *)malloc(particle_cnt * sizeof(float));
-    long idx                 = 0;
+    data_contig_md *data_out;
+    H5B_MALLOC(data_out, sizeof(data_contig_md));
+    data_out->particle_cnt = particle_cnt;
+    data_out->dim_1        = dim_1;
+    data_out->dim_2        = dim_2;
+    data_out->dim_3        = dim_3;
+    H5B_MALLOC(data_out->x, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->y, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->z, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->px, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->py, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->pz, particle_cnt * sizeof(float));
+    H5B_MALLOC(data_out->id_1, particle_cnt * sizeof(int));
+    H5B_MALLOC(data_out->id_2, particle_cnt * sizeof(float));
+    long idx = 0;
     for (long i1 = 0; i1 < dim_1; i1++) {
         for (long i2 = 0; i2 < dim_2; i2++) {
             for (long i3 = 0; i3 < dim_3; i3++) {
@@ -444,20 +448,28 @@ data_write_contig_contig_MD_array(time_step *ts, hid_t loc, hid_t *dset_ids, hid
 
     dset_ids[0] = H5Dcreate_async(loc, "x", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[0], "H5Dcreate_async(x)");
     dset_ids[1] = H5Dcreate_async(loc, "y", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[1], "H5Dcreate_async(y)");
     dset_ids[2] = H5Dcreate_async(loc, "z", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[2], "H5Dcreate_async(z)");
     dset_ids[3] = H5Dcreate_async(loc, "px", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[3], "H5Dcreate_async(px)");
     dset_ids[4] = H5Dcreate_async(loc, "py", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[4], "H5Dcreate_async(py)");
     dset_ids[5] = H5Dcreate_async(loc, "pz", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[5], "H5Dcreate_async(pz)");
     dset_ids[6] = H5Dcreate_async(loc, "id_1", H5T_NATIVE_INT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[6], "H5Dcreate_async(id_1)");
     dset_ids[7] = H5Dcreate_async(loc, "id_2", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT,
                                   ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[7], "H5Dcreate_async(id_2)");
     unsigned t2 = get_time_usec();
 
     ierr =
@@ -497,6 +509,7 @@ data_write_contig_to_interleaved(time_step *ts, hid_t loc, hid_t *dset_ids, hid_
     unsigned t1 = get_time_usec();
     dset_ids[0] = H5Dcreate_async(loc, "particles", PARTICLE_COMPOUND_TYPE, filespace, H5P_DEFAULT, dcpl,
                                   H5P_DEFAULT, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[0], "H5Dcreate_async(particles)");
     unsigned t2 = get_time_usec();
     ierr = H5Dwrite_async(dset_ids[0], PARTICLE_COMPOUND_TYPE_SEPARATES[0], memspace, filespace, plist_id,
                           data_in->x, ts->es_data);
@@ -535,20 +548,28 @@ data_write_interleaved_to_contig(time_step *ts, hid_t loc, hid_t *dset_ids, hid_
     unsigned t1 = get_time_usec();
     dset_ids[0] = H5Dcreate_async(loc, "x", PARTICLE_COMPOUND_TYPE_SEPARATES[0], filespace, H5P_DEFAULT, dcpl,
                                   H5P_DEFAULT, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[0], "H5Dcreate_async(x)");
     dset_ids[1] = H5Dcreate_async(loc, "y", PARTICLE_COMPOUND_TYPE_SEPARATES[1], filespace, H5P_DEFAULT, dcpl,
                                   H5P_DEFAULT, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[1], "H5Dcreate_async(y)");
     dset_ids[2] = H5Dcreate_async(loc, "z", PARTICLE_COMPOUND_TYPE_SEPARATES[2], filespace, H5P_DEFAULT, dcpl,
                                   H5P_DEFAULT, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[2], "H5Dcreate_async(z)");
     dset_ids[3] = H5Dcreate_async(loc, "px", PARTICLE_COMPOUND_TYPE_SEPARATES[3], filespace, H5P_DEFAULT,
                                   dcpl, H5P_DEFAULT, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[3], "H5Dcreate_async(px)");
     dset_ids[4] = H5Dcreate_async(loc, "py", PARTICLE_COMPOUND_TYPE_SEPARATES[4], filespace, H5P_DEFAULT,
                                   dcpl, H5P_DEFAULT, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[4], "H5Dcreate_async(py)");
     dset_ids[5] = H5Dcreate_async(loc, "pz", PARTICLE_COMPOUND_TYPE_SEPARATES[5], filespace, H5P_DEFAULT,
                                   dcpl, H5P_DEFAULT, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[5], "H5Dcreate_async(pz)");
     dset_ids[6] = H5Dcreate_async(loc, "id_1", PARTICLE_COMPOUND_TYPE_SEPARATES[6], filespace, H5P_DEFAULT,
                                   dcpl, H5P_DEFAULT, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[6], "H5Dcreate_async(id_1)");
     dset_ids[7] = H5Dcreate_async(loc, "id_2", PARTICLE_COMPOUND_TYPE_SEPARATES[7], filespace, H5P_DEFAULT,
                                   dcpl, H5P_DEFAULT, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[7], "H5Dcreate_async(id_2)");
     unsigned t2 = get_time_usec();
     ierr        = H5Dwrite_async(dset_ids[0], PARTICLE_COMPOUND_TYPE, memspace, filespace, plist_id, data_in,
                           ts->es_data);
@@ -587,6 +608,7 @@ data_write_interleaved_to_interleaved(time_step *ts, hid_t loc, hid_t *dset_ids,
     unsigned t1 = get_time_usec();
     dset_ids[0] = H5Dcreate_async(loc, "particles", PARTICLE_COMPOUND_TYPE, filespace, H5P_DEFAULT, dcpl,
                                   H5P_DEFAULT, ts->es_meta_create);
+    H5B_CHECK_HID(dset_ids[0], "H5Dcreate_async(particles)");
     unsigned t2 = get_time_usec();
     ierr        = H5Dwrite_async(dset_ids[0], PARTICLE_COMPOUND_TYPE, memspace, filespace, plist_id, data_in,
                           ts->es_data);
@@ -732,10 +754,10 @@ _run_benchmark_write(bench_params params, hid_t file_id, hid_t fapl, hid_t files
     for (int ts_index = 0; ts_index < timestep_cnt; ts_index++) {
         meta_time1 = 0, meta_time2 = 0, meta_time3 = 0, meta_time4 = 0, meta_time5 = 0;
         time_step *ts = &(MEM_MONITOR->time_steps[ts_index]);
+        assert(ts);
         MEM_MONITOR->mem_used += ts->mem_size;
         //        print_mem_bound(MEM_MONITOR);
         snprintf(grp_name, sizeof(grp_name), "Timestep_%d", ts_index);
-        assert(ts);
 
         if (params.cnt_time_step_delay > 0) {
             if (ts_index > params.cnt_time_step_delay - 1) // delayed close on all ids of the previous ts
@@ -747,6 +769,7 @@ _run_benchmark_write(bench_params params, hid_t file_id, hid_t fapl, hid_t files
         t0 = get_time_usec();
         ts->grp_id =
             H5Gcreate_async(file_id, grp_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT, ts->es_meta_create);
+        H5B_CHECK_HID(ts->grp_id, "H5Gcreate_async");
         t1         = get_time_usec();
         meta_time3 = (t1 - t0);
 
@@ -943,7 +966,13 @@ main(int argc, char *argv[])
 {
     int mpi_thread_lvl_provided = -1;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_thread_lvl_provided);
-    assert(MPI_THREAD_MULTIPLE == mpi_thread_lvl_provided);
+    if (mpi_thread_lvl_provided != MPI_THREAD_MULTIPLE) {
+        fprintf(stderr,
+                "h5bench_write_unlimited: MPI implementation does not provide MPI_THREAD_MULTIPLE "
+                "(got level %d)\n",
+                mpi_thread_lvl_provided);
+        h5bench_die(NULL);
+    }
     MPI_Comm_rank(MPI_COMM_WORLD, &MY_RANK);
     MPI_Comm_size(MPI_COMM_WORLD, &NUM_RANKS);
     MPI_Comm           comm    = MPI_COMM_WORLD;
@@ -1045,6 +1074,7 @@ main(int argc, char *argv[])
     else {
         file_id = H5Fcreate_async(output_file, H5F_ACC_TRUNC, H5P_DEFAULT, fapl, 0);
     }
+    H5B_CHECK_HID(file_id, "H5Fcreate_async");
     unsigned long tfopen_end = get_time_usec();
 
     if (MY_RANK == 0)


### PR DESCRIPTION
Re-applies the content of #153, which was squash-merged into the now-deleted `wave-a-correctness-b` branch and did not propagate to `develop`.

## Summary

* Wraps the remaining `malloc` calls in `h5bench_append.c`, `h5bench_overwrite.c`, `h5bench_write_normal_dist.c`, and `h5bench_write_unlimited.c` with `H5B_MALLOC`.
* Adds `H5B_CHECK_HID` on dataset/group open and create calls in the same files, mirroring the earlier coverage of `h5bench_read.c` and `h5bench_write.c`.

## Test plan

* [x] Build with HDF5 1.14.x and confirm the pattern binaries compile.
* [x] Run a small `h5bench_append` configuration locally to make sure the new checks do not trigger spurious failures.

Recovery PR. Original squash commit: 232d03b.