### PR TITLE
E3SM wrapper: parallel build, out of source, install, gated gcc flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,15 +185,43 @@ endif()
 # https://github.com/Parallel-NetCDF/E3SM-IO
 
 if(H5BENCH_E3SM)
+    # Upstream E3SM-IO is autotools-only. Keep the ExternalProject wrapper but:
+    #   * build out of source (BUILD_IN_SOURCE 0) so the submodule stays clean
+    #     (autoreconf still writes configure/Makefile.in back into the source
+    #     tree — that's a limitation of autotools itself);
+    #   * let the outer Make jobserver parallelise via $(MAKE) instead of the
+    #     hard-coded -j 1;
+    #   * only pass -fno-var-tracking-assignments when building with GCC
+    #     (it's a gcc-specific debug-info slowdown workaround);
+    #   * add an install(PROGRAMS) rule so `cmake --install` actually ships
+    #     the binary into bin/ alongside the other h5bench_* executables.
+
+    set(h5bench_e3sm_cflags "")
+    if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+        set(h5bench_e3sm_cflags
+            CFLAGS=-fno-var-tracking-assignments
+            CXXFLAGS=-fno-var-tracking-assignments
+        )
+    endif()
+
     ExternalProject_Add(h5bench_e3sm
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/e3sm
-        CONFIGURE_COMMAND autoreconf -i COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/e3sm/configure --prefix=${CMAKE_BINARY_DIR} --with-hdf5=${HDF5_HOME} CFLAGS=-fno-var-tracking-assignments CXXFLAGS=-fno-var-tracking-assignments
-        BUILD_COMMAND make -j 1
-        INSTALL_COMMAND ${CMAKE_COMMAND} -E copy src/e3sm_io ${CMAKE_BINARY_DIR}/h5bench_e3sm
-        BUILD_IN_SOURCE 1
+        BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/e3sm-build
+        CONFIGURE_COMMAND
+            autoreconf -i ${CMAKE_CURRENT_SOURCE_DIR}/e3sm
+            COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/e3sm/configure
+                --prefix=${CMAKE_BINARY_DIR}
+                --with-hdf5=${HDF5_HOME}
+                ${h5bench_e3sm_cflags}
+        BUILD_COMMAND $(MAKE)
+        INSTALL_COMMAND ${CMAKE_COMMAND} -E copy <BINARY_DIR>/src/e3sm_io ${CMAKE_BINARY_DIR}/h5bench_e3sm
+        BUILD_IN_SOURCE 0
         LOG_CONFIGURE 1
         LOG_BUILD 1
+        LOG_INSTALL 1
     )
+
+    install(PROGRAMS ${CMAKE_BINARY_DIR}/h5bench_e3sm DESTINATION bin)
 endif()
 
 # OpenPMD #####################################################################


### PR DESCRIPTION
Re-applies the content of #156, which was squash-merged into the now-deleted `wave-b-cmake` branch and did not propagate to `develop`.

## Summary

* Drops `BUILD_COMMAND make -j 1` in favour of `$(MAKE)` so the outer Make jobserver forwards `-jN` into the E3SM-IO build.
* Switches to `BUILD_IN_SOURCE 0` with an explicit `BINARY_DIR`, keeping `e3sm/` clean of object files and Makefiles (autoreconf still writes back into the source tree, an autotools limitation).
* Gates `CFLAGS=-fno-var-tracking-assignments` on `CMAKE_C_COMPILER_ID STREQUAL "GNU"` so Clang does not warn or ignore it.
* Adds `install(PROGRAMS ${CMAKE_BINARY_DIR}/h5bench_e3sm DESTINATION bin)` so `cmake --install` actually ships the binary.

## Test plan

* [x] Configure with `-DH5BENCH_E3SM=ON` and confirm the build still succeeds.
* [x] Run `cmake --install` and confirm `h5bench_e3sm` ends up in the install `bin/`.

Recovery PR. Original squash commit: 83695ea. The E3SM block conflicted with develop's older version, resolved by taking the updated wrapper.