### PR TITLE
Add pre-commit config and CI check

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,29 @@
+name: pre-commit
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Vendored submodules are excluded in .pre-commit-config.yaml
+          # but a shallow clone with no submodules is still what we want.
+          submodules: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,51 @@
+# Pre-commit hooks for h5bench-owned code. Vendored submodules
+# (amrex/e3sm/macsio/openpmd) are excluded so pre-commit does not try
+# to reformat upstream sources.
+#
+# Trailing-whitespace and end-of-file-fixer are intentionally omitted
+# at first landing: the tree has ~90 files with trailing whitespace
+# and ~62 without a final newline that would need a separate cleanup
+# sweep. Add them in a follow-up PR once that sweep lands.
+#
+# Install locally:  pip install pre-commit && pre-commit install
+
+default_language_version:
+  python: python3
+
+exclude: |
+  (?x)^(
+    amrex/|
+    e3sm/|
+    macsio/|
+    openpmd/
+  )
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-yaml
+        # PyYAML in check-yaml does not understand !reference or the
+        # GitHub Actions ${{ }} template syntax on its own, but plain
+        # YAML syntax errors still get flagged.
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: [--maxkb=512]
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v10.0.1
+    hooks:
+      - id: clang-format
+        types_or: [c, c++]
+        # Mirror the existing clang-format-check.yml scope: h5bench-owned
+        # sources only. Vendored submodules are already excluded above.
+        files: \.(c|h|cpp|hpp)$
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8
+        # Matches the existing lint.yml scope so the two checks agree.
+        files: ^src/.*\.py$
+        args: [--config=tox.ini]


### PR DESCRIPTION
Wave D item 21. Wires up pre-commit so contributors catch formatting drift and basic sanity errors before pushing, and CI enforces the same set.

## Summary

* \`.pre-commit-config.yaml\` at repo root.
* \`.github/workflows/pre-commit.yml\` runs \`pre-commit run --all-files\` on every PR and on pushes to develop/master.

Hooks (h5bench-owned code only; vendored \`amrex\`/\`e3sm\`/\`macsio\`/\`openpmd\` excluded via top-level \`exclude:\`):

* \`check-yaml\`, \`check-json\`, \`check-merge-conflict\`, \`check-added-large-files\`
* \`clang-format\` pinned to v10 to match the existing \`clang-format-check.yml\` workflow.
* \`flake8\` scoped to \`src/*.py\`, using \`tox.ini\`, to match the existing \`lint.yml\` workflow.

\`trailing-whitespace\` and \`end-of-file-fixer\` are intentionally out of scope for this PR: the tree has ~90 files with trailing whitespace and ~62 missing a final newline that would need a separate cleanup sweep first. Track as a follow-up.

## Local usage

\`\`\`
pip install pre-commit
pre-commit install
pre-commit run --all-files
\`\`\`

## Test plan

* [ ] \`pre-commit run --all-files\` passes locally on a clean develop checkout.
* [ ] The new \`pre-commit\` CI job passes on this PR.
* [ ] The existing \`clang-format Check\` and \`Python Lint\` jobs are unchanged.