### PR TITLE
Add clang-tidy and cppcheck CI jobs

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,37 @@
+# clang-tidy config for h5bench-owned C sources.
+#
+# The set below is intentionally conservative: bugprone + a subset of
+# readability/performance/portability that has low false-positive rate on
+# an MPI+HDF5 C codebase. Individual noisy checks are opted out because
+# they either fight the existing style (align-*, magic-numbers) or would
+# require rewriting stable public benchmark APIs (function-cognitive-
+# complexity, non-const-parameter).
+#
+# The workflow runs clang-tidy in report-only mode. Tighten with
+# WarningsAsErrors once the tree is clean for a given check family.
+
+Checks: >-
+  -*,
+  bugprone-*,
+  readability-*,
+  performance-*,
+  portability-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-narrowing-conversions,
+  -bugprone-reserved-identifier,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -readability-magic-numbers,
+  -readability-identifier-length,
+  -readability-braces-around-statements,
+  -readability-implicit-bool-conversion,
+  -readability-function-cognitive-complexity,
+  -readability-isolate-declaration,
+  -readability-non-const-parameter,
+  -readability-else-after-return,
+  -readability-named-parameter,
+  -readability-avoid-const-params-in-decls,
+  -readability-uppercase-literal-suffix
+
+WarningsAsErrors: ''
+FormatStyle: file
+HeaderFilterRegex: '^(commons|h5bench_patterns|exerciser|metadata_stress)/'

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,71 @@
+name: clang-tidy
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  clang-tidy:
+    name: clang-tidy
+    runs-on: ubuntu-24.04
+    # Report-only for the first landing. Once a check family is clean on
+    # h5bench-owned code, promote it via WarningsAsErrors in .clang-tidy
+    # and drop this flag.
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: false
+
+      - name: Install clang-tidy and dev headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            clang-tidy \
+            libhdf5-openmpi-dev \
+            libopenmpi-dev
+          # libhdf5-openmpi-dev installs headers under
+          # /usr/include/hdf5/openmpi so clang-tidy can resolve hdf5.h
+          # without a full source build. Same for mpi.h.
+
+      - name: Generate compile_commands.json
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DCMAKE_C_COMPILER=mpicc \
+            -DHDF5_HOME=/usr/include/hdf5/openmpi \
+            -DH5BENCH_ALL=OFF
+
+      - name: Run clang-tidy on h5bench-owned code
+        run: |
+          # Scope: only h5bench-owned .c files. Vendored submodules
+          # (amrex/e3sm/macsio/openpmd) are excluded by not being listed.
+          # clang-tidy reads .clang-tidy from the repo root automatically.
+          FILES=$(find commons h5bench_patterns exerciser metadata_stress \
+                    -maxdepth 3 -name '*.c' 2>/dev/null | sort)
+
+          echo '--- files to analyze ---'
+          printf '%s\n' "$FILES"
+          echo '--- clang-tidy output ---'
+
+          clang-tidy \
+            -p build \
+            --quiet \
+            $FILES 2>&1 | tee clang-tidy.txt || true
+
+      - name: Upload clang-tidy report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: clang-tidy-report
+          path: clang-tidy.txt
+          retention-days: 14

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,63 @@
+name: cppcheck
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cppcheck:
+    name: cppcheck
+    runs-on: ubuntu-24.04
+    # Report-only for the first landing; individual finding families can
+    # be tightened later by dropping error-exitcode or promoting a subset
+    # of checks with --error-exitcode=1.
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: false
+
+      - name: Install cppcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cppcheck
+
+      - name: Run cppcheck on h5bench-owned code
+        run: |
+          # Scope: only directories h5bench owns. Vendored submodules
+          # (amrex/e3sm/macsio/openpmd) are excluded implicitly by not
+          # being listed.
+          #
+          # missingIncludeSystem: silences the noise about not finding
+          # hdf5.h/mpi.h; cppcheck already tolerates unresolved system
+          # headers via --suppress.
+          cppcheck \
+            --enable=warning,style,performance,portability \
+            --inline-suppr \
+            --suppress=missingIncludeSystem \
+            --suppress=unusedFunction \
+            --std=c99 \
+            --language=c \
+            --error-exitcode=0 \
+            --output-file=cppcheck.txt \
+            commons/ h5bench_patterns/ exerciser/ metadata_stress/
+
+          echo '--- cppcheck report ---'
+          cat cppcheck.txt || true
+
+      - name: Upload cppcheck report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cppcheck-report
+          path: cppcheck.txt
+          retention-days: 14


### PR DESCRIPTION
Wave D item 20. Two new report-only static-analysis workflows plus a curated \`.clang-tidy\` config.

CodeQL for C is already covered by the existing GitHub-default CodeQL setup (\`Analyze (c-cpp)\` runs on every PR), so this PR does not need to touch that.

## Summary

* \`.clang-tidy\` — enables \`bugprone-*\`, \`readability-*\`, \`performance-*\`, \`portability-*\` and opts out of the style-fighting and high-false-positive checks (\`magic-numbers\`, \`identifier-length\`, \`braces-around-statements\`, \`isolate-declaration\`, \`function-cognitive-complexity\`, \`easily-swappable-parameters\`, etc.). \`HeaderFilterRegex\` limits header findings to h5bench-owned dirs.
* \`.github/workflows/cppcheck.yml\` — scans \`commons/\` \`h5bench_patterns/\` \`exerciser/\` \`metadata_stress/\` with \`warning+style+performance+portability\`. Uploads the full report as an artifact. \`--error-exitcode=0\` so it is report-only on first landing.
* \`.github/workflows/clang-tidy.yml\` — installs \`libhdf5-openmpi-dev\` on the runner so system HDF5 headers resolve without a full source build, runs \`cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON\`, then invokes clang-tidy against h5bench-owned \`.c\` files. \`continue-on-error: true\` at job level.

## Follow-up path (not in this PR)

Once each check family is triaged and clean, promote to blocking by:

* Removing \`continue-on-error: true\` from the workflow.
* For cppcheck: dropping \`--error-exitcode=0\`.
* For clang-tidy: adding entries to \`WarningsAsErrors\` in \`.clang-tidy\`.

## Test plan

* [ ] \`cppcheck\` job runs to completion on this PR and uploads its artifact.
* [ ] \`clang-tidy\` job runs to completion and uploads its artifact.
* [ ] Neither blocks the merge because both are \`continue-on-error\`.