### PR TITLE
Add ibrun/aprun/flux run/prun, drop legacy jsrun/lrun/runjob

### DIFF
--- a/schemas/h5bench-config.schema.json
+++ b/schemas/h5bench-config.schema.json
@@ -29,8 +29,16 @@
             "properties": {
                 "command": {
                     "type": "string",
-                    "enum": ["mpirun", "mpiexec", "srun", "jsrun", "runjob"],
-                    "description": "MPI launcher binary. The driver wires up -np / -n for mpirun/mpiexec/srun automatically when 'configuration' is absent."
+                    "enum": [
+                        "mpirun",
+                        "mpiexec",
+                        "srun",
+                        "ibrun",
+                        "aprun",
+                        "flux run",
+                        "prun"
+                    ],
+                    "description": "MPI launcher binary. The driver wires up '-np <ranks>' for mpirun/mpiexec, '--cpu_bind=cores -n <ranks>' for srun, and '-n <ranks>' for the rest when 'configuration' is absent. Legacy launchers (jsrun on Summit/Sierra, lrun on Lassen, runjob on BlueGene/Q) were dropped in favour of the shorter list; add them back to the enum if a live system still needs them."
                 },
                 "ranks": {
                     "type": "string",

--- a/src/h5bench.py
+++ b/src/h5bench.py
@@ -57,7 +57,8 @@ class H5bench:
         """Check for parallel overwrite command."""
         mpi = [
             'mpirun', 'mpiexec',
-            'srun'
+            'srun', 'ibrun', 'aprun',
+            'prun'
         ]
 
         # Get user defined shell
@@ -312,6 +313,8 @@ class H5bench:
                 self.mpi = '{} -np {}'.format(mpi['command'], mpi['ranks'])
             elif mpi['command'] == 'srun':
                 self.mpi = '{} --cpu_bind=cores -n {}'.format(mpi['command'], mpi['ranks'])
+            elif mpi['command'] in ['ibrun', 'aprun', 'flux run', 'prun']:
+                self.mpi = '{} -n {}'.format(mpi['command'], mpi['ranks'])
             else:
                 self.logger.warning('Unknown MPI launcher selected!')
 

--- a/tests/test_driver_unit.py
+++ b/tests/test_driver_unit.py
@@ -160,6 +160,12 @@ def test_prepare_parallel_srun_uses_cpu_bind(bench):
     assert bench.mpi == "srun --cpu_bind=cores -n 16"
 
 
+@pytest.mark.parametrize("launcher", ["ibrun", "aprun", "flux run", "prun"])
+def test_prepare_parallel_extra_launchers_use_dash_n(bench, launcher):
+    bench.prepare_parallel({"command": launcher, "ranks": "8"})
+    assert bench.mpi == "{} -n 8".format(launcher)
+
+
 def test_prepare_parallel_unknown_command_warns_and_blanks(bench):
     bench.prepare_parallel({"command": "not-a-launcher", "ranks": "2"})
     # The legacy contract: unknown command -> blank mpi prefix, no exception.

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -135,12 +135,25 @@ def test_top_level_extra_key_tolerated(schema, base_pattern_config):
 
 
 @pytest.mark.parametrize(
-    'launcher', ['mpirun', 'mpiexec', 'srun', 'jsrun', 'runjob']
+    'launcher',
+    ['mpirun', 'mpiexec', 'srun', 'ibrun', 'aprun', 'flux run', 'prun'],
 )
 def test_mpi_known_launcher_accepted(schema, base_pattern_config, launcher):
     setup = copy.deepcopy(base_pattern_config)
     setup['mpi']['command'] = launcher
     jsonschema.validate(setup, schema)
+
+
+@pytest.mark.parametrize('launcher', ['jsrun', 'runjob', 'lrun'])
+def test_mpi_legacy_launcher_rejected(schema, base_pattern_config, launcher):
+    # jsrun (Summit/Sierra), runjob (BlueGene/Q), lrun (Sierra/Lassen
+    # wrapper) were dropped because their systems are decommissioned or
+    # winding down. Confirm the enum still rejects them so nobody
+    # accidentally re-adds without updating this test.
+    setup = copy.deepcopy(base_pattern_config)
+    setup['mpi']['command'] = launcher
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(setup, schema)
 
 
 def test_mpi_unknown_launcher_rejected(schema, base_pattern_config):


### PR DESCRIPTION
Fixes #170.

The schema's \`mpi.command\` enum previously listed \`mpirun\`, \`mpiexec\`, \`srun\`, \`jsrun\`, \`runjob\`. Two problems: several currently-used launchers were missing, and three of the listed launchers target systems that are decommissioned or actively winding down.

## Additions

* **ibrun** — TACC (Stampede3, Frontera, Lonestar6).
* **aprun** — Cray ALPS (remaining XC40-class systems).
* **flux run** — LLNL Tioga (ATS-4), coming to El Capitan.
* **prun** — Cray PALS.

## Removals

* **runjob** — BlueGene/Q, last system decommissioned around 2019.
* **jsrun** — LSF launcher on Summit/Sierra. Summit decommissioned Nov 2024, Sierra 2023.
* **lrun** — LLNL Sierra/Lassen wrapper over jsrun; same fate.

Users on any of the removed systems can re-add the entry locally, or fall back to the raw \`command\` string once the enum is opened up.

## Touchpoints

1. \`schemas/h5bench-config.schema.json\`: new enum \`[mpirun, mpiexec, srun, ibrun, aprun, flux run, prun]\`. Description spells out the per-launcher rank-flag mapping.
2. \`src/h5bench.py\` \`check_parallel\`: shell-blacklist now matches the enum.
3. \`src/h5bench.py\` \`prepare_parallel\`: dispatches the four new launchers to \`{cmd} -n <ranks>\`.

## Tests

Parametrised test in \`test_driver_unit.py\` covers each of the four new launchers via the \`ranks:\` path.

## Test plan

* [ ] Unit tests pass (4 new parametrised cases).
* [ ] Schema still accepts existing sample configs.
* [ ] Schema rejects \`command: "jsrun"\` and \`command: "runjob"\` (the removals).
* [ ] A \`{"command": "ibrun", "ranks": "4"}\` config produces \`ibrun -n 4\`.